### PR TITLE
Update SCIREG_HTTP_CONSUMER_URLS to new endpoint

### DIFF
--- a/conf.example/envs/metadata_scireg.env
+++ b/conf.example/envs/metadata_scireg.env
@@ -3,4 +3,4 @@ CLICKHOUSE_CACHER_TABLES=${CLICKHOUSE_SCIREG_METADATA_TABLE}
 CLICKHOUSE_METADATA_FORCE_UPDATE=false # Set to true to force updates even if no changes detected
 HTTP_CONSUMER_ENV_PREFIX=SCIREG
 SCIREG_HTTP_CONSUMER_UPDATE_INTERVAL=3600
-SCIREG_HTTP_CONSUMER_URLS="https://epoc-rabbitmq.tacc.utexas.edu/NetSage/scireg.json"
+SCIREG_HTTP_CONSUMER_URLS="https://downloads.netsage.io/scireg.json"


### PR DESCRIPTION
This file had the old URL, which is a redirect to the new URL, but might go away someday.