### PR TITLE
Add DynamicPipeline for use with ClickHouse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 # Install system dependencies for ClickHouse client
 RUN apt-get update && apt-get install -y \
-    gcc \
+    gcc git \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better Docker layer caching

--- a/bin/run.py
+++ b/bin/run.py
@@ -1,33 +1,42 @@
 import argparse
 import os
 import logging
+
 from metranova.pipelines.base import YAMLPipeline
+from metranova.storage import __version__
 
 # Configure logging
 log_level = logging.INFO
-if os.getenv('DEBUG', 'false').lower() == 'true' or os.getenv('DEBUG') == '1':
+if os.getenv("DEBUG", "false").lower() == "true" or os.getenv("DEBUG") == "1":
     log_level = logging.DEBUG
-    
+
 logging.basicConfig(
-    level=log_level,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    level=log_level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
+
 def main():
     """Main entry point"""
-    logger.info("Starting MetrANOVA Pipeline")
+    logger.info(f"Starting MetrANOVA Pipeline using metranova.storage={__version__}")
     pipeline = None
     try:
-        #Get YAML file from args or env
+        # Get YAML file from args or env
         parser = argparse.ArgumentParser(description="MetrANOVA Pipeline Runner")
-        parser.add_argument('--pipeline', type=str, required=False, help='YAML file defining the pipeline configuration')
+        parser.add_argument(
+            "--pipeline",
+            type=str,
+            required=False,
+            help="YAML file defining the pipeline configuration",
+        )
         args = parser.parse_args()
-        pipeline_yaml = args.pipeline or os.getenv('PIPELINE_YAML', None)
+        pipeline_yaml = args.pipeline or os.getenv("PIPELINE_YAML", None)
         if not pipeline_yaml:
-            raise ValueError("Pipeline YAML configuration file must be provided via --pipeline argument or PIPELINE_YAML environment variable")
+            raise ValueError(
+                "Pipeline YAML configuration file must be provided via --pipeline argument or PIPELINE_YAML environment variable"
+            )
 
-        #Load pipeline from YAML
+        # Load pipeline from YAML
         pipeline = YAMLPipeline(yaml_file=pipeline_yaml)
         logger.info(f"Loaded pipeline {pipeline}")
 
@@ -37,11 +46,12 @@ def main():
         logger.info("Shutting down due to keyboard interrupt")
     except Exception as e:
         logger.error(f"Application error: {e}")
-        raise 
+        raise
     finally:
         # Clean shutdown
         if pipeline:
             pipeline.close()
+
 
 if __name__ == "__main__":
     main()

--- a/metranova/__init__.py
+++ b/metranova/__init__.py
@@ -1,5 +1,0 @@
-"""
-Metranova Package
-"""
-
-__version__ = "1.0.0"

--- a/metranova/connectors/kafka.py
+++ b/metranova/connectors/kafka.py
@@ -2,8 +2,9 @@ import logging
 import os
 from confluent_kafka import Consumer, KafkaError
 from metranova.connectors.base import BaseConnector
-    
+
 logger = logging.getLogger(__name__)
+
 
 class KafkaConnector(BaseConnector):
     def __init__(self):
@@ -14,57 +15,93 @@ class KafkaConnector(BaseConnector):
         """Initialize Kafka consumer with SSL configuration"""
         try:
             # Get Kafka configuration from environment variables
-            bootstrap_servers = os.getenv('KAFKA_BOOTSTRAP_SERVERS', 'localhost:9092')
-            topic = os.getenv('KAFKA_TOPIC', 'metranova_flow')
-            group_id = os.getenv('KAFKA_CONSUMER_GROUP', 'ch-writer-group')
-            #generate a client id based on random uuid
+            bootstrap_servers = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+            topic = os.getenv("KAFKA_TOPIC", "metranova_flow")
+            group_id = os.getenv("KAFKA_CONSUMER_GROUP", "ch-writer-group")
+            # generate a client id based on random uuid
             client_id = f"ch-writer-{os.urandom(4).hex()}"
 
             # SSL configuration
-            ssl_ca_location = os.getenv('KAFKA_SSL_CA_LOCATION', '/app/conf/certificates/ca-cert')
-            ssl_certificate_location = os.getenv('KAFKA_SSL_CERTIFICATE_LOCATION', '/app/conf/certificates/client-cert')
-            ssl_key_location = os.getenv('KAFKA_SSL_KEY_LOCATION', '/app/conf/certificates/client-key')
-            ssl_key_password = os.getenv('KAFKA_SSL_KEY_PASSWORD')
-            
+            ssl_ca_location = os.getenv(
+                "KAFKA_SSL_CA_LOCATION", "/app/conf/certificates/ca-cert"
+            )
+            ssl_certificate_location = os.getenv(
+                "KAFKA_SSL_CERTIFICATE_LOCATION", "/app/conf/certificates/client-cert"
+            )
+            ssl_key_location = os.getenv(
+                "KAFKA_SSL_KEY_LOCATION", "/app/conf/certificates/client-key"
+            )
+            ssl_key_password = os.getenv("KAFKA_SSL_KEY_PASSWORD")
+
             # Base consumer configuration
             consumer_config = {
-                'bootstrap.servers': bootstrap_servers,
-                'group.id': group_id,
-                'client.id': client_id,
-                'auto.offset.reset': os.getenv('KAFKA_AUTO_OFFSET_RESET', 'latest'),
-                'enable.auto.commit': os.getenv('KAFKA_ENABLE_AUTO_COMMIT', 'true').lower() == 'true',
-                'auto.commit.interval.ms': int(os.getenv('KAFKA_AUTO_COMMIT_INTERVAL_MS', '5000')),
-                'session.timeout.ms': int(os.getenv('KAFKA_SESSION_TIMEOUT_MS', '30000')),
-                'heartbeat.interval.ms': int(os.getenv('KAFKA_HEARTBEAT_INTERVAL_MS', '10000')),
-                'max.poll.interval.ms': int(os.getenv('KAFKA_MAX_POLL_INTERVAL_MS', '300000')),
-                'fetch.min.bytes': int(os.getenv('KAFKA_FETCH_MIN_BYTES', '1')),
-                'fetch.max.bytes': int(os.getenv('KAFKA_FETCH_MAX_BYTES', '52428800')),  # 50MB - default
+                "bootstrap.servers": bootstrap_servers,
+                "group.id": group_id,
+                "client.id": client_id,
+                "group.protocol": "classic",
+                "auto.offset.reset": os.getenv("KAFKA_AUTO_OFFSET_RESET", "latest"),
+                "enable.auto.commit": os.getenv(
+                    "KAFKA_ENABLE_AUTO_COMMIT", "true"
+                ).lower()
+                == "true",
+                "auto.commit.interval.ms": int(
+                    os.getenv("KAFKA_AUTO_COMMIT_INTERVAL_MS", "5000")
+                ),
+                "session.timeout.ms": int(
+                    os.getenv("KAFKA_SESSION_TIMEOUT_MS", "50000")
+                ),
+                "heartbeat.interval.ms": int(
+                    os.getenv("KAFKA_HEARTBEAT_INTERVAL_MS", "5000")
+                ),
+                "max.poll.interval.ms": int(
+                    os.getenv("KAFKA_MAX_POLL_INTERVAL_MS", "300000")
+                ),
+                "fetch.min.bytes": int(os.getenv("KAFKA_FETCH_MIN_BYTES", "1")),
+                "fetch.max.bytes": int(
+                    os.getenv("KAFKA_FETCH_MAX_BYTES", "52428800")
+                ),  # 50MB - default
             }
-            
+
             # Add SSL configuration if certificates are provided
             if ssl_ca_location and os.path.exists(ssl_ca_location):
                 self.logger.info("Configuring Kafka SSL authentication")
-                consumer_config.update({
-                    'security.protocol': 'SSL',
-                    'ssl.ca.location': ssl_ca_location,
-                    'ssl.certificate.location': ssl_certificate_location,
-                    'ssl.key.location': ssl_key_location,
-                    'ssl.endpoint.identification.algorithm': os.getenv('KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM', 'https'),
-                })
-                
+                consumer_config.update(
+                    {
+                        "security.protocol": "SSL",
+                        "ssl.ca.location": ssl_ca_location,
+                        "ssl.certificate.location": ssl_certificate_location,
+                        "ssl.key.location": ssl_key_location,
+                        "ssl.endpoint.identification.algorithm": os.getenv(
+                            "KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM", "https"
+                        ),
+                    }
+                )
+
                 # Add key password if provided
                 if ssl_key_password:
-                    consumer_config['ssl.key.password'] = ssl_key_password
-                    
+                    consumer_config["ssl.key.password"] = ssl_key_password
+
             else:
-                self.logger.warning("SSL certificates not found, using PLAINTEXT protocol")
-                consumer_config['security.protocol'] = 'PLAINTEXT'
-            
+                self.logger.warning(
+                    "SSL certificates not found, using PLAINTEXT protocol"
+                )
+                consumer_config["security.protocol"] = "PLAINTEXT"
+
             # Create consumer
             self.client = Consumer(consumer_config)
-            self.client.subscribe([topic])
 
-            self.logger.info(f"Kafka consumer initialized for topic: {topic}")
+            metadata = self.client.list_topics(topic=topic, timeout=10)
+
+            topic_metadata = metadata.topics.get(topic)
+            if topic_metadata is None:
+                raise RuntimeError("Topic does not exist")
+            if topic_metadata.error is not None:
+                raise RuntimeError(f"Topic error: {topic_metadata.error}")
+
+            self.client.subscribe([topic])
+            self.logger.info(
+                f"Kafka consumer initialized for topic '{topic}'. Topic has {len(topic_metadata.partitions)} partitions."
+            )
             self.logger.info(f"Bootstrap servers: {bootstrap_servers}")
             self.logger.info(f"Group ID: {group_id}")
             self.logger.info(f"Client ID: {client_id}")

--- a/metranova/consumers/kafka.py
+++ b/metranova/consumers/kafka.py
@@ -7,24 +7,27 @@ from confluent_kafka import KafkaError
 
 logger = logging.getLogger(__name__)
 
+
 class KafkaConsumer(BaseConsumer):
     """Kafka consumer with SSL authentication using confluent-kafka"""
-    
+
     def __init__(self, pipeline: BasePipeline):
         super().__init__(pipeline)
         self.logger = logger
         self.datasource = KafkaConnector()
-    
+
     def consume_messages(self):
         """Consume messages from Kafka"""
         msg = self.datasource.client.poll(timeout=1.0)
         if msg is None:
             return
-        
+
         # check for errors
         if msg.error():
             if msg.error().code() == KafkaError._PARTITION_EOF:
-                self.logger.debug(f"End of partition reached {msg.topic()}/{msg.partition()}")
+                self.logger.debug(
+                    f"End of partition reached {msg.topic()}/{msg.partition()}"
+                )
                 return
             else:
                 self.logger.error(f"Kafka error: {msg.error()}")
@@ -33,15 +36,18 @@ class KafkaConsumer(BaseConsumer):
         # format the response as JSON
         msg_data = orjson.loads(msg.value()) if msg.value() else None
         msg_metadata = {
-            'topic': msg.topic(),
-            'partition': msg.partition(),
-            'offset': msg.offset(),
-            'timestamp': msg.timestamp()[1] if msg.timestamp() else None,
-            'key': msg.key().decode('utf-8') if msg.key() else None
+            "topic": msg.topic(),
+            "partition": msg.partition(),
+            "offset": msg.offset(),
+            "timestamp": msg.timestamp()[1] if msg.timestamp() else None,
+            "key": msg.key().decode("utf-8") if msg.key() else None,
         }
 
         # Process the message
         try:
+            logger.info(
+                f"Processing message from topic: {msg_metadata['topic']} with offset: {msg_metadata['offset']}"
+            )
             self.pipeline.process_message(msg_data, consumer_metadata=msg_metadata)
         except Exception as e:
             self.logger.error(f"Error processing message: {e}")

--- a/metranova/consumers/kafka.py
+++ b/metranova/consumers/kafka.py
@@ -45,7 +45,7 @@ class KafkaConsumer(BaseConsumer):
 
         # Process the message
         try:
-            logger.info(
+            self.logger.debug(
                 f"Processing message from topic: {msg_metadata['topic']} with offset: {msg_metadata['offset']}"
             )
             self.pipeline.process_message(msg_data, consumer_metadata=msg_metadata)

--- a/metranova/consumers/kafka.py
+++ b/metranova/consumers/kafka.py
@@ -34,7 +34,13 @@ class KafkaConsumer(BaseConsumer):
                 return
 
         # format the response as JSON
-        msg_data = orjson.loads(msg.value()) if msg.value() else None
+        try:
+            msg_data = orjson.loads(msg.value()) if msg.value() else None
+        except orjson.JSONDecodeError as e:
+            self.logger.error(
+                f"Skipping malformed message at offset {msg.offset()}: {e}"
+            )
+            return
         msg_metadata = {
             "topic": msg.topic(),
             "partition": msg.partition(),

--- a/metranova/pipelines/base.py
+++ b/metranova/pipelines/base.py
@@ -10,6 +10,7 @@ from metranova.processors.base import BaseProcessor
 
 logger = logging.getLogger(__name__)
 
+
 class BasePipeline:
     def __init__(self):
         # setup logger
@@ -25,7 +26,9 @@ class BasePipeline:
     def start(self):
         if self.consumers:
             for consumer in self.consumers:
-                thread = threading.Thread(target=consumer.consume, name=f"Consumer-{type(consumer).__name__}")
+                thread = threading.Thread(
+                    target=consumer.consume, name=f"Consumer-{type(consumer).__name__}"
+                )
                 thread.daemon = True
                 thread.start()
                 self.consumer_threads.append(thread)
@@ -33,7 +36,7 @@ class BasePipeline:
         else:
             self.logger.warning("No consumers to start")
 
-        # block until threads are done (they won't be, unless there's an error)       
+        # block until threads are done (they won't be, unless there's an error)
         for thread in self.consumer_threads:
             thread.join()
 
@@ -46,34 +49,37 @@ class BasePipeline:
             return
         for writer in self.writers:
             writer.process_message(msg, consumer_metadata)
-    
+
     def load_classes(self, class_str: str, init_args={}, required_class=None) -> List:
         classes = []
         if class_str:
-            for class_name in class_str.split(','):
+            for class_name in class_str.split(","):
                 class_name = class_name.strip()
                 if not class_name:
                     continue
                 try:
-                    module_name, class_name = class_name.rsplit('.', 1)
+                    module_name, class_name = class_name.rsplit(".", 1)
                     module = importlib.import_module(module_name)
                     cls = getattr(module, class_name)
-                    
-                    if required_class is None or issubclass(cls, required_class):
-                        classes.append(cls(**init_args))
-                    else:
-                        self.logger.warning(f"Class {class_name} is not a subclass of {required_class.__name__}, skipping")
-                        
+
+                    if not issubclass(cls, required_class):
+                        self.logger.warning(
+                            f"Class {class_name} is not a subclass of {required_class.__name__}. I hope you know what you're doing."
+                        )
+                    classes.append(cls(**init_args))
+
                 except (ImportError, AttributeError) as e:
                     self.logger.error(f"Failed to load class {class_name}: {e}")
-        
+
             if classes:
-                self.logger.info(f"Loaded {len(classes)} classes: {[type(p).__name__ for p in classes]}")
-            else: 
+                self.logger.info(
+                    f"Loaded {len(classes)} classes: {[type(p).__name__ for p in classes]}"
+                )
+            else:
                 self.logger.warning("No valid ClickHouse processors loaded")
-        else: 
-            self.logger.warning("Processors string is empty") 
-        
+        else:
+            self.logger.warning("Processors string is empty")
+
         return classes
 
     def close(self):
@@ -88,7 +94,9 @@ class BasePipeline:
             for thread in self.consumer_threads:
                 thread.join(timeout=10.0)  # Wait up to 10 seconds per thread
                 if thread.is_alive():
-                    self.logger.warning(f"Thread {thread.name} did not finish within timeout")
+                    self.logger.warning(
+                        f"Thread {thread.name} did not finish within timeout"
+                    )
             self.consumer_threads.clear()
             self.logger.info("Consumer threads cleanup completed")
 
@@ -103,62 +111,86 @@ class BasePipeline:
             self.logger.info("Cachers closed")
 
     def __str__(self):
-        #return a string that lists the consumers, cachers, and writer names and writer proccessor names
+        # return a string that lists the consumers, cachers, and writer names and writer proccessor names
         consumer_names = [type(c).__name__ for c in self.consumers]
-        cacher_names = [f"{name}:{type(c).__name__}" for name, c in self.cachers.items()]
+        cacher_names = [
+            f"{name}:{type(c).__name__}" for name, c in self.cachers.items()
+        ]
         writer_names = []
         for w in self.writers:
-            processor_names = [type(p).__name__ for p in w.processors] if hasattr(w, 'processors') else []
+            processor_names = (
+                [type(p).__name__ for p in w.processors]
+                if hasattr(w, "processors")
+                else []
+            )
             writer_names.append(f"{type(w).__name__} (Processors: {processor_names})")
         return f"Pipeline(Consumers: {consumer_names}, Cachers: {cacher_names}, Writers: {writer_names})"
 
-        
+
 class YAMLPipeline(BasePipeline):
     def __init__(self, yaml_file: dict):
         super().__init__()
         self.yaml_file = yaml_file
         self.logger = logger
-        
-        #load yaml content
+
+        # load yaml content
         yaml_config = None
         try:
-            with open(self.yaml_file, 'r') as file:
+            with open(self.yaml_file, "r") as file:
                 yaml_config = yaml.safe_load(file)
-            self.logger.info(f"Loaded pipeline YAML configuration from {self.yaml_file}")
+            self.logger.info(
+                f"Loaded pipeline YAML configuration from {self.yaml_file}"
+            )
             self.logger.debug(f"YAML content: {yaml_config}")
         except yaml.YAMLError as e:
             self.logger.error(f"Error parsing YAML file: {e}")
             raise e
         if not yaml_config:
             raise ValueError("YAML configuration is empty or invalid")
- 
-        #load consumers
-        for consumer_cfg in yaml_config.get('consumers', []):
-            consumer_type = consumer_cfg.get('type')
+
+        # load consumers
+        for consumer_cfg in yaml_config.get("consumers", []):
+            consumer_type = consumer_cfg.get("type")
             if consumer_type:
-                self.consumers.extend(self.load_classes(consumer_type, init_args={'pipeline': self}, required_class=BaseConsumer))
-        
-        #load cachers
-        for cacher_cfg in yaml_config.get('cachers', []):
-            cacher_type = cacher_cfg.get('type')
-            cacher_name = cacher_cfg.get('name', None)
-            if  cacher_type and cacher_name:
-                cacher_instances = self.load_classes(cacher_type, required_class=BaseCacher)
+                self.consumers.extend(
+                    self.load_classes(
+                        consumer_type,
+                        init_args={"pipeline": self},
+                        required_class=BaseConsumer,
+                    )
+                )
+
+        # load cachers
+        for cacher_cfg in yaml_config.get("cachers", []):
+            cacher_type = cacher_cfg.get("type")
+            cacher_name = cacher_cfg.get("name", None)
+            if cacher_type and cacher_name:
+                cacher_instances = self.load_classes(
+                    cacher_type, required_class=BaseCacher
+                )
                 if cacher_instances:
                     self.cachers[cacher_name] = cacher_instances[0]
-        
-        #load writers
-        for writer_cfg in yaml_config.get('writers', []):
-            #get writer type
-            writer_type = writer_cfg.get('type', None)
+
+        # load writers
+        for writer_cfg in yaml_config.get("writers", []):
+            # get writer type
+            writer_type = writer_cfg.get("type", None)
             if not writer_type:
                 self.logger.warning("Writer type not specified in YAML, skipping")
                 continue
-            #load processors for writer if any
+            # load processors for writer if any
             processor_list = []
-            for processor_type in writer_cfg.get('processors', []):
-                processor_instances = self.load_classes(processor_type, init_args={'pipeline': self}, required_class=BaseProcessor)
+            for processor_type in writer_cfg.get("processors", []):
+                processor_instances = self.load_classes(
+                    processor_type,
+                    init_args={"pipeline": self},
+                    required_class=BaseProcessor,
+                )
                 processor_list.extend(processor_instances)
-            #load writer with processors if any
-            writer_instances = self.load_classes(writer_type, init_args={'processors': processor_list}, required_class=BaseWriter)
+            # load writer with processors if any
+            writer_instances = self.load_classes(
+                writer_type,
+                init_args={"processors": processor_list},
+                required_class=BaseWriter,
+            )
             self.writers.extend(writer_instances)

--- a/metranova/processors/clickhouse/base.py
+++ b/metranova/processors/clickhouse/base.py
@@ -348,7 +348,7 @@ class BaseClickHouseProcessor(BaseProcessor, BaseClickHouseTableMixin):
                 ref_results[f"{direction}_ip_{ext}_ref"] = ref[0]
         return ref_results
 
-    def column_names(self) -> list:
+    def column_names(self, table_name: str = None) -> list:
         """Return list of column names for insertion into ClickHouse"""
         column_names = []
         columns_seen = {} #track columns seen so we don't add duplicates - can't use set since order matters

--- a/metranova/processors/clickhouse/base.py
+++ b/metranova/processors/clickhouse/base.py
@@ -5,6 +5,7 @@ import re
 import hashlib
 import orjson
 from metranova.processors.base import BaseProcessor
+from clickhouse_connect.driver.httpclient import HttpClient
 
 logger = logging.getLogger(__name__)
 
@@ -640,6 +641,16 @@ class BaseDataProcessor(BaseClickHouseProcessor):
             ["policy_scope", "Array(LowCardinality(String))", True],
             ["ext", None, True]
         ]
+
+    def set_clickhouse_client(self, client: HttpClient) -> None:
+        """Set the ClickHouse client for this processor and any child classes that need it
+
+        The primary purpose of this method is to grant the processor direct access to the ClickHouse client.
+        While in most cases the processor will declare the database schema itself, the dynamic pipeline is
+        required to access the type definitions directly as they are declared via API.
+        """
+        self.ch_client = client
+
 
 class BaseDataGenericMetricProcessor(BaseDataProcessor):
     def __init__(self, pipeline):

--- a/metranova/processors/clickhouse/base.py
+++ b/metranova/processors/clickhouse/base.py
@@ -648,8 +648,11 @@ class BaseDataProcessor(BaseClickHouseProcessor):
         The primary purpose of this method is to grant the processor direct access to the ClickHouse client.
         While in most cases the processor will declare the database schema itself, the dynamic pipeline is
         required to access the type definitions directly as they are declared via API.
+
+        NOTE: This method exists primarily to support the dynamic pipeline and may not be necessary for
+        other use cases.
         """
-        self.ch_client = client
+        return None
 
 
 class BaseDataGenericMetricProcessor(BaseDataProcessor):

--- a/metranova/processors/clickhouse/dynamic.py
+++ b/metranova/processors/clickhouse/dynamic.py
@@ -20,26 +20,52 @@ class DynamicProcessor(object):
         self.pipeline = pipeline
         logger.error(f"DynamicProcessor initialized with pipeline: {pipeline}")
 
+        self.datatypes = {}
+        self.columns = {}
+
     @property
     def table(self):
         """Total hack to allow dynamic table names"""
         return "dynamic_table"
 
-    def match_message(self, value: dict) -> bool:
-        logger.error(f"Matching message for value: {value.values()}")
-        # load measurement types
-        return True
+    # Abuse is / not logic to allow for both true/false and table name return values
+    def match_message(self, value: dict) -> str:
+        logger.error(f"Matching message for value: {value}")
+
+        datatypes = self.api.get_data_types()
+        logger.info(datatypes)
+
+        for datatype in datatypes:
+            matches = True
+            for field in [
+                f["field_name"]
+                for f in datatype["data_fields"]
+                if f["nullable"] is False
+            ]:
+                if field not in value["tags"]:
+                    logger.info(
+                        f"Field {field} not found in {datatype['name']}.data_fields"
+                    )
+                    matches = False
+                    break
+            if matches:
+                logger.info(f"All fields matched for datatype {datatype['name']}.")
+                return "data_" + datatype["name"]
+        return None
 
     def scale_value(self, value, scale):
         return value
 
     def build_message(self, value: dict, src_metadata: dict) -> list[dict[str, any]]:
-        logger.error(
-            f"Building message for value: {value} with metadata: {src_metadata}"
-        )
-        return [
-            {"node": "example", "intf": "0/0/0", "rx_bytes": 1000, "tx_bytes": 2000}
-        ]
+        logger.error(f"Building message: {value} with metadata: {src_metadata}")
+        result = value["fields"]
+        result["node"] = value["tags"].get("node", "unknown")
+        result["insert_time"] = value["timestamp"]
+        table_name = self.match_message(value)
+
+        self.columns[table_name] = list(result.keys())
+        result["_clickhouse_table"] = table_name
+        return [result]
 
     def has_match_field(self, value: dict) -> bool:
         # load measurement types
@@ -54,6 +80,11 @@ class DynamicProcessor(object):
         return []
 
     def get_materialized_views(self) -> list:
+        """Used to declare table names to be created on ClickHouse side
+
+        We return an empty list here because the dynamic processor is designed to handle
+        dynamic table names that are created by users via API.
+        """
         return []
 
     def load_materialized_views(
@@ -67,16 +98,28 @@ class DynamicProcessor(object):
     def lookup_ip_ref_extensions(self, ip_address: str, direction: str) -> dict:
         return {}
 
-    def column_names(self) -> list:
-        return []
+    def column_names(self, table_name: str = None) -> list:
+        logger.info(f"Getting column names for table: {table_name}")
+        return self.columns.get(table_name, [])
 
     def message_to_columns(self, message: dict, table_name: str) -> list:
-        return []
+        return list(message.values())
 
-    def get_table_names(self):
+    def get_table_names(self) -> list:
+        """Used to declare table names to be created on ClickHouse side
+
+        We return an empty list here because the dynamic processor is designed to handle
+        dynamic table names that are created by users via API.
+        """
         return []
 
     def create_table_command(self, table_name=None) -> str:
+        """Use to create the tables returned by get_table_names
+
+        We ignore the table_name parameter here because the dynamic processor is designed
+        to handle dynamic table names that are created by users via API. Instead, we
+        return a command that will always succeed.
+        """
         return "SELECT 1"
 
     def get_extension_defs(
@@ -97,3 +140,22 @@ class DynamicProcessor(object):
         required to access the type definitions directly as they are declared via API.
         """
         self.ch_client = client
+        self.api = MetranovaSyncApi(client)
+
+
+class MetranovaSyncApi:
+    """Class for interacting with Metranova Sync API"""
+
+    def __init__(self, client: HttpClient):
+        self.client = client
+
+    def get_data_types(self) -> list[dict]:
+        """Get the data types defined in Metranova Sync"""
+        try:
+            result = self.client.query(f"""
+                SELECT * FROM metranova.definition WHERE notEmpty(data_fields)
+            """)
+            return list(result.named_results())
+        except Exception as e:
+            logger.exception(f"Error retrieving all resource types: {e}")
+            return None

--- a/metranova/processors/clickhouse/dynamic.py
+++ b/metranova/processors/clickhouse/dynamic.py
@@ -13,136 +13,6 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
-class DynamicProcessor(object):
-    """Processor for handling user defined measurement types"""
-
-    def __init__(self, pipeline):
-        self.pipeline = pipeline
-        logger.error(f"DynamicProcessor initialized with pipeline: {pipeline}")
-
-        self.datatypes = {}
-        self.columns = {}
-
-    @property
-    def table(self):
-        """Total hack to allow dynamic table names"""
-        return "dynamic_table"
-
-    # Abuse is / not logic to allow for both true/false and table name return values
-    def match_message(self, value: dict) -> str:
-        logger.error(f"Matching message for value: {value}")
-
-        datatypes = self.api.get_data_types()
-        logger.info(datatypes)
-
-        for datatype in datatypes:
-            matches = True
-            for field in [
-                f["field_name"]
-                for f in datatype["data_fields"]
-                if f["nullable"] is False
-            ]:
-                if field not in value["tags"]:
-                    logger.info(
-                        f"Field {field} not found in {datatype['name']}.data_fields"
-                    )
-                    matches = False
-                    break
-            if matches:
-                logger.info(f"All fields matched for datatype {datatype['name']}.")
-                return "data_" + datatype["name"]
-        return None
-
-    def scale_value(self, value, scale):
-        return value
-
-    def build_message(self, value: dict, src_metadata: dict) -> list[dict[str, any]]:
-        logger.error(f"Building message: {value} with metadata: {src_metadata}")
-        result = value["fields"]
-        result["node"] = value["tags"].get("node", "unknown")
-        result["insert_time"] = value["timestamp"]
-        table_name = self.match_message(value)
-
-        self.columns[table_name] = list(result.keys())
-        result["_clickhouse_table"] = table_name
-        return [result]
-
-    def has_match_field(self, value: dict) -> bool:
-        # load measurement types
-        logger.error(f"Checking match fields for value: {value.values()}")
-        return True
-
-    def has_required_fields(self, value: dict) -> bool:
-        # load measurement types.
-        return True
-
-    def get_ch_dictionaries(self) -> list:
-        return []
-
-    def get_materialized_views(self) -> list:
-        """Used to declare table names to be created on ClickHouse side
-
-        We return an empty list here because the dynamic processor is designed to handle
-        dynamic table names that are created by users via API.
-        """
-        return []
-
-    def load_materialized_views(
-        self, env_var_name: str, mv_class: type[BaseClickHouseMaterializedViewMixin]
-    ) -> None:
-        return None
-
-    def get_ip_ref_extensions(self, env_var_name: str) -> list:
-        return []
-
-    def lookup_ip_ref_extensions(self, ip_address: str, direction: str) -> dict:
-        return {}
-
-    def column_names(self, table_name: str = None) -> list:
-        logger.info(f"Getting column names for table: {table_name}")
-        return self.columns.get(table_name, [])
-
-    def message_to_columns(self, message: dict, table_name: str) -> list:
-        return list(message.values())
-
-    def get_table_names(self) -> list:
-        """Used to declare table names to be created on ClickHouse side
-
-        We return an empty list here because the dynamic processor is designed to handle
-        dynamic table names that are created by users via API.
-        """
-        return []
-
-    def create_table_command(self, table_name=None) -> str:
-        """Use to create the tables returned by get_table_names
-
-        We ignore the table_name parameter here because the dynamic processor is designed
-        to handle dynamic table names that are created by users via API. Instead, we
-        return a command that will always succeed.
-        """
-        return "SELECT 1"
-
-    def get_extension_defs(
-        self, env_var_name: str, extension_options: dict, json_column_name: str = "ext"
-    ) -> list:
-        return []
-
-    def extension_is_enabled(
-        self, extension_name: str, json_column_name: str = "ext"
-    ) -> bool:
-        return False
-
-    def set_clickhouse_client(self, client: HttpClient) -> None:
-        """Set the ClickHouse client for this processor and any child classes that need it
-
-        The primary purpose of this method is to grant the processor direct access to the ClickHouse client.
-        While in most cases the processor will declare the database schema itself, the dynamic pipeline is
-        required to access the type definitions directly as they are declared via API.
-        """
-        self.ch_client = client
-        self.api = MetranovaSyncApi(client)
-
-
 class MetranovaSyncApi:
     """Class for interacting with Metranova Sync API"""
 
@@ -159,3 +29,182 @@ class MetranovaSyncApi:
         except Exception as e:
             logger.exception(f"Error retrieving all resource types: {e}")
             return None
+
+
+class ResourceDefinition:
+    """Class representing a resource definition as defined by Metranova API"""
+
+    _FIXED_COLUMNS = ["insert_time"]
+
+    def __init__(self, definition: dict):
+        self._name: str = definition["name"]
+        self._data_fields: list[dict] = definition.get("data_fields", [])
+        self._required_field_names: list[str] = [
+            f["field_name"] for f in self._data_fields if f["nullable"] is False
+        ]
+        self._data_field_names: list[str] = [f["field_name"] for f in self._data_fields]
+        logger.info(
+            f"Initialized ResourceDefinition for {self._name} with required fields {self._required_field_names}."
+        )
+
+    @property
+    def table_name(self) -> str:
+        return "data_" + self._name
+
+    def applies_to(self, message: dict) -> bool:
+        fields = message.get("fields", {})
+        tags = message.get("tags", {})
+        return all(f in fields or f in tags for f in self._required_field_names)
+
+    def columns(self) -> list[str]:
+        return self._data_field_names + self._FIXED_COLUMNS
+
+    def to_rows(self, message: dict, metadata: dict) -> list[dict]:
+        fields = message.get("fields", {})
+        tags = message.get("tags", {})
+        row = {}
+        for field_name in self._data_field_names:
+            field_val = fields.get(field_name)
+            if field_val is None:
+                field_val = tags.get(field_name)
+            row[field_name] = field_val
+        row["insert_time"] = message.get("timestamp")
+        row["_clickhouse_table"] = (
+            self.table_name
+        )  # Included to assist with batch processing
+        return [row]
+
+
+class DynamicProcessor(object):
+    """Processor for handling user defined measurement types"""
+
+    def __init__(self, pipeline):
+        self.pipeline = pipeline
+        self.resource_definitions = {}
+        logger.info(f"DynamicProcessor initialized with pipeline: {pipeline}")
+
+    def set_clickhouse_client(self, client: HttpClient) -> None:
+        """Set the ClickHouse client for this processor and any child classes that need it
+
+        The primary purpose of this method is to grant the processor direct access to the ClickHouse client.
+        While in most cases the processor will declare the database schema itself, the dynamic pipeline is
+        required to access the type definitions directly as they are declared via API.
+        """
+        self.ch_client = client
+        self.api = MetranovaSyncApi(client)
+
+        rdefs = self.api.get_data_types()
+        for rd in rdefs:
+            self.resource_definitions["data_" + rd["name"]] = ResourceDefinition(rd)
+
+    def build_message(self, value: dict, src_metadata: dict) -> list[dict[str, any]]:
+        rdef = self._find_resource_definition(value)
+        if rdef is None:
+            logger.warning(
+                f"No matching resource definition found for message with fields: {value.get('fields', {})} and tags: {value.get('tags', {})}"
+            )
+            return None
+        logger.info(f"Built message: {value} with metadata: {src_metadata}")
+        return rdef.to_rows(value, src_metadata)
+
+    def match_message(self, value: dict) -> str:
+        rdef = self._find_resource_definition(value)
+        if rdef is None:
+            return None
+        logger.info(f"All fields matched for datatype {rdef._name}.")
+        return rdef.table_name
+
+    def column_names(self, table_name: str = None) -> list:
+        rdef = self.resource_definitions.get(table_name)
+        if rdef is None:
+            logger.warning(
+                f"No resource definition found for table {table_name}. Writer is attempting to save to a table with no loaded/existing resource definitions."
+            )
+            return []
+
+        cols = rdef.columns()
+        logger.info(f"Got column names {cols} for table {table_name}.")
+        return cols
+
+    def scale_value(self, value, scale):
+        # TODO
+        return value
+
+    # These are helper methods
+
+    def _find_resource_definition(self, value: dict) -> ResourceDefinition | None:
+        for rd in self.resource_definitions.values():
+            if rd.applies_to(value):
+                return rd
+        return None
+
+    @property
+    def table(self) -> str:
+        return "invalid_table"
+
+    # TODO Review these methods for implemtation
+
+    def get_ch_dictionaries(self) -> list:
+        return []
+
+    def load_materialized_views(
+        self, env_var_name: str, mv_class: type[BaseClickHouseMaterializedViewMixin]
+    ) -> None:
+        return None
+
+    def get_ip_ref_extensions(self, env_var_name: str) -> list:
+        return []
+
+    def lookup_ip_ref_extensions(self, ip_address: str, direction: str) -> dict:
+        return {}
+
+    def message_to_columns(self, message: dict, table_name: str) -> list:
+        return list(message.values())
+
+    def get_extension_defs(
+        self, env_var_name: str, extension_options: dict, json_column_name: str = "ext"
+    ) -> list:
+        return []
+
+    def extension_is_enabled(
+        self, extension_name: str, json_column_name: str = "ext"
+    ) -> bool:
+        return False
+
+    # Everything below this not actually used. We just need it to satisfy the interface
+    # requirements of the ClickHouse writer.
+
+    def has_match_field(self, value: dict) -> bool:
+        # load measurement types
+        logger.warning(f"Calling has_match_field. This isn't important.")
+        return True
+
+    def has_required_fields(self, value: dict) -> bool:
+        # load measurement types
+        logger.warning(f"Calling has_required_fields. This isn't important.")
+        return True
+
+    def create_table_command(self, table_name=None) -> str:
+        """Use to create the tables returned by get_table_names
+
+        We ignore the table_name parameter here because the dynamic processor is designed
+        to handle dynamic table names that are created by users via API. Instead, we
+        return a command that will always succeed.
+        """
+        return "SELECT 1"
+
+    def get_materialized_views(self) -> list:
+        """Used to declare table names to be created on ClickHouse side
+
+        We return an empty list here because the dynamic processor is designed to handle
+        dynamic table names that are created by users via API.
+        """
+        return []
+
+    def get_table_names(self) -> list:
+        """Used to declare table names to be created on ClickHouse side
+
+        We return an empty list here because the dynamic processor is designed to handle
+        dynamic table names that are created by users via API.
+        """
+        return []

--- a/metranova/processors/clickhouse/dynamic.py
+++ b/metranova/processors/clickhouse/dynamic.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import os
 
 from metranova.processors.clickhouse.base import (
     BaseClickHouseMaterializedViewMixin,
@@ -11,22 +12,67 @@ from clickhouse_connect.driver.httpclient import HttpClient
 logger = logging.getLogger(__name__)
 
 
+class ResourceDefinition:
+    """Class representing a resource definition as defined by Metranova API"""
+
+    _FIXED_COLUMNS = ["insert_time"]
+
+    def __init__(self, definition: dict):
+        self._slug: str = definition["slug"]
+        self._data_fields: list[dict] = definition.get("data_fields", [])
+        self._required_field_names: list[str] = [
+            f["field_name"] for f in self._data_fields if f["nullable"] is False
+        ]
+        self._data_field_names: list[str] = [f["field_name"] for f in self._data_fields]
+        logger.info(
+            f"Initialized ResourceDefinition for {self._slug} with required fields {self._required_field_names}."
+        )
+
+    @property
+    def table_name(self) -> str:
+        return "data_" + self._slug
+
+    def applies_to(self, message: dict) -> bool:
+        return (
+            message.get(os.getenv("PROCESSOR_DYNAMIC_RESOURCE_TYPE_FIELD_NAME", "name"))
+            == self._slug
+        )
+
+    def columns(self) -> list[str]:
+        return self._data_field_names + self._FIXED_COLUMNS
+
+    def to_rows(self, message: dict, metadata: dict) -> list[dict]:
+        fields = message.get("fields", {})
+        tags = message.get("tags", {})
+        row = {}
+        for field_name in self._data_field_names:
+            field_val = fields.get(field_name)
+            if field_val is None:
+                field_val = tags.get(field_name)
+            row[field_name] = field_val
+        row["insert_time"] = message.get("timestamp")
+        row["_clickhouse_table"] = (
+            self.table_name
+        )  # Included to assist with batch processing
+        return [row]
+
+
 class MetranovaSyncApi:
     """Class for interacting with Metranova Sync API"""
 
     def __init__(self, client: HttpClient):
         self.client = client
 
-    def get_data_types(self) -> list[dict]:
+    def get_data_types(self) -> list[ResourceDefinition]:
         """Get the data types defined in Metranova Sync"""
         try:
             result = self.client.query(f"""
                 SELECT * FROM metranova.definition WHERE notEmpty(data_fields)
             """)
-            return list(result.named_results())
+            return [ResourceDefinition(rdef) for rdef in result.named_results()]
         except Exception as e:
             logger.exception(f"Error retrieving all resource types: {e}")
-            return None
+            return []
 
     def get_transformers(self) -> list[Transformer]:
         """Get all transformers and their columns from ClickHouse"""
@@ -70,48 +116,27 @@ class MetranovaSyncApi:
         ]
 
 
-class ResourceDefinition:
-    """Class representing a resource definition as defined by Metranova API"""
+class DynamicProcessorConfig:
+    """Configuration class for DynamicProcessor
 
-    _FIXED_COLUMNS = ["insert_time"]
+    Environment variables:
 
-    def __init__(self, definition: dict):
-        self._name: str = definition["slug"]
-        self._data_fields: list[dict] = definition.get("data_fields", [])
-        self._required_field_names: list[str] = [
-            f["field_name"] for f in self._data_fields if f["nullable"] is False
-        ]
-        self._data_field_names: list[str] = [f["field_name"] for f in self._data_fields]
-        logger.info(
-            f"Initialized ResourceDefinition for {self._name} with required fields {self._required_field_names}."
+        # Comma separated list of resource types to process. If no value is provided all
+        # resource types will be processed. Default value is "".
+        PROCESSOR_DYNAMIC_RESOURCE_TYPES=interface,cpu
+
+        # Name of the field contained in each message defining its resource type.
+        # Messages received without this type will be dropped. Default value is "name".
+        PROCESSOR_DYNAMIC_RESOURCE_TYPE_FIELD_NAME=
+    """
+
+    def __init__(self):
+        rtype_val = os.getenv("PROCESSOR_DYNAMIC_RESOURCE_TYPES", "")
+        self.resource_types = set(rtype_val.split(",")) if rtype_val else set()
+
+        self.resource_type_field_name = os.getenv(
+            "PROCESSOR_DYNAMIC_RESOURCE_TYPE_FIELD_NAME", "name"
         )
-
-    @property
-    def table_name(self) -> str:
-        return "data_" + self._name
-
-    def applies_to(self, message: dict) -> bool:
-        fields = message.get("fields", {})
-        tags = message.get("tags", {})
-        return all(f in fields or f in tags for f in self._required_field_names)
-
-    def columns(self) -> list[str]:
-        return self._data_field_names + self._FIXED_COLUMNS
-
-    def to_rows(self, message: dict, metadata: dict) -> list[dict]:
-        fields = message.get("fields", {})
-        tags = message.get("tags", {})
-        row = {}
-        for field_name in self._data_field_names:
-            field_val = fields.get(field_name)
-            if field_val is None:
-                field_val = tags.get(field_name)
-            row[field_name] = field_val
-        row["insert_time"] = message.get("timestamp")
-        row["_clickhouse_table"] = (
-            self.table_name
-        )  # Included to assist with batch processing
-        return [row]
 
 
 class DynamicProcessor(object):
@@ -122,6 +147,8 @@ class DynamicProcessor(object):
         self.resource_definitions = {}
         self.resource_definitions_loaded_at = None
         self.transformers = {}
+        self.config = DynamicProcessorConfig()
+
         logger.info(f"DynamicProcessor initialized with pipeline: {pipeline}")
 
     def set_clickhouse_client(self, client: HttpClient) -> None:
@@ -134,35 +161,64 @@ class DynamicProcessor(object):
         self.ch_client = client
         self.api = MetranovaSyncApi(client)
 
-        rdefs = self.api.get_data_types()
-        for rd in rdefs:
-            self.resource_definitions["data_" + rd["slug"]] = ResourceDefinition(rd)
+        self.resource_definitions = {r.table_name: r for r in self.api.get_data_types()}
         self.resource_definitions_loaded_at = datetime.datetime.now()
 
         self.transformers = {t.id: t for t in self.api.get_transformers()}
 
-    def build_message(self, value: dict, src_metadata: dict) -> list[dict[str, any]]:
-        rdef = self._find_resource_definition(value)
+    def build_message(self, msg: dict, src_metadata: dict) -> list[dict[str, any]]:
+        msg_type: str = msg.get(self.config.resource_type_field_name, None)
+        if msg_type is None:
+            logger.error(
+                f"Error building message: Resource type field {self.config.resource_type_field_name} is missing. This should not have happened!"
+            )
+            return None
+
+        if self.config.resource_types and msg_type not in self.config.resource_types:
+            logger.error(
+                f"Error building message: Message resource type {msg_type} not a configured resource type {self.config.resource_types}, skipping message. This should not have happened!"
+            )
+            return None
+
+        rdef = self._find_resource_definition(msg)
         if rdef is None:
-            logger.warning(
-                f"No matching resource definition found for message with fields: {value.get('fields', {})} and tags: {value.get('tags', {})}"
+            logger.error(
+                f"Error building message: No ResourceDefinition loaded for message with name: '{msg.get('name')}' fields: {msg.get('fields', {})} and tags: {msg.get('tags', {})}. This should not have happened!"
             )
             return None
 
         for transformer in self.transformers.values():
             for column in transformer.columns:
                 if column.match_value == src_metadata.get(transformer.match_field):
-                    column.apply(value)
+                    column.apply(msg)
 
-        logger.info(f"Built message: {value} with metadata: {src_metadata}")
-        return rdef.to_rows(value, src_metadata)
+        logger.info(f"Built message: {msg} with metadata: {src_metadata}")
+        return rdef.to_rows(msg, src_metadata)
 
-    def match_message(self, value: dict) -> str:
-        rdef = self._find_resource_definition(value)
+    def match_message(self, msg: dict) -> str:
+        msg_type: str = msg.get(self.config.resource_type_field_name, None)
+        if msg_type is None:
+            logger.info(
+                f"Received message without resource type field '{self.config.resource_type_field_name}', skipping message."
+            )
+            return False
+
+        if self.config.resource_types and msg_type not in self.config.resource_types:
+            # TODO: Log the message type and count of dropped messages of each type for better observability
+            logger.warning(
+                f"Message resource type {msg_type} not a configured resource type {self.config.resource_types}, skipping message."
+            )
+            return False
+
+        rdef = self._find_resource_definition(msg)
         if rdef is None:
-            return None
-        logger.info(f"All fields matched for datatype {rdef._name}.")
-        return rdef.table_name
+            # TODO: Log the message type and count of dropped messages of each type for better observability
+            logger.warning(
+                f"No ResourceDefinition loaded for message with name: '{msg.get('name')}' fields: {msg.get('fields', {})} and tags: {msg.get('tags', {})}, skipping message."
+            )
+            return False
+
+        return True
 
     def column_names(self, table_name: str = None) -> list:
         rdef = self.resource_definitions.get(table_name)
@@ -189,9 +245,9 @@ class DynamicProcessor(object):
             datetime.datetime.now() - self.resource_definitions_loaded_at
             > datetime.timedelta(minutes=1)
         ):
-            rdefs = self.api.get_data_types()
-            for rd in rdefs:
-                self.resource_definitions["data_" + rd["slug"]] = ResourceDefinition(rd)
+            self.resource_definitions = {
+                r.table_name: r for r in self.api.get_data_types()
+            }
             self.resource_definitions_loaded_at = datetime.datetime.now()
 
             self.transformers = {t.id: t for t in self.api.get_transformers()}

--- a/metranova/processors/clickhouse/dynamic.py
+++ b/metranova/processors/clickhouse/dynamic.py
@@ -138,10 +138,6 @@ class DynamicProcessor(object):
                 return rd
         return None
 
-    @property
-    def table(self) -> str:
-        return "invalid_table"
-
     # TODO Review these methods for implemtation
 
     def get_ch_dictionaries(self) -> list:
@@ -174,14 +170,16 @@ class DynamicProcessor(object):
     # Everything below this not actually used. We just need it to satisfy the interface
     # requirements of the ClickHouse writer.
 
+    @property
+    def table(self) -> str:
+        return "invalid_table"
+
     def has_match_field(self, value: dict) -> bool:
         # load measurement types
-        logger.warning(f"Calling has_match_field. This isn't important.")
         return True
 
     def has_required_fields(self, value: dict) -> bool:
         # load measurement types
-        logger.warning(f"Calling has_required_fields. This isn't important.")
         return True
 
     def create_table_command(self, table_name=None) -> str:

--- a/metranova/processors/clickhouse/dynamic.py
+++ b/metranova/processors/clickhouse/dynamic.py
@@ -1,14 +1,9 @@
 import logging
-import os
-import re
-from typing import Iterator
+
 from metranova.processors.clickhouse.base import (
     BaseClickHouseMaterializedViewMixin,
 )
 from clickhouse_connect.driver.httpclient import HttpClient
-
-import orjson
-import yaml
 
 logger = logging.getLogger(__name__)
 

--- a/metranova/processors/clickhouse/dynamic.py
+++ b/metranova/processors/clickhouse/dynamic.py
@@ -19,6 +19,11 @@ class DynamicProcessor(object):
         self.pipeline = pipeline
         logger.error(f"DynamicProcessor initialized with pipeline: {pipeline}")
 
+    @property
+    def table(self):
+        """Total hack to allow dynamic table names"""
+        return "dynamic_table"
+
     def match_message(self, value: dict) -> bool:
         logger.error(f"Matching message for value: {value.values()}")
         # load measurement types

--- a/metranova/processors/clickhouse/dynamic.py
+++ b/metranova/processors/clickhouse/dynamic.py
@@ -5,6 +5,7 @@ from typing import Iterator
 from metranova.processors.clickhouse.base import (
     BaseClickHouseMaterializedViewMixin,
 )
+from clickhouse_connect.driver.httpclient import HttpClient
 
 import orjson
 import yaml
@@ -87,3 +88,12 @@ class DynamicProcessor(object):
         self, extension_name: str, json_column_name: str = "ext"
     ) -> bool:
         return False
+
+    def set_clickhouse_client(self, client: HttpClient) -> None:
+        """Set the ClickHouse client for this processor and any child classes that need it
+
+        The primary purpose of this method is to grant the processor direct access to the ClickHouse client.
+        While in most cases the processor will declare the database schema itself, the dynamic pipeline is
+        required to access the type definitions directly as they are declared via API.
+        """
+        self.ch_client = client

--- a/metranova/processors/clickhouse/dynamic.py
+++ b/metranova/processors/clickhouse/dynamic.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 
 from metranova.processors.clickhouse.base import (
@@ -76,6 +77,7 @@ class DynamicProcessor(object):
     def __init__(self, pipeline):
         self.pipeline = pipeline
         self.resource_definitions = {}
+        self.resource_definitions_loaded_at = None
         logger.info(f"DynamicProcessor initialized with pipeline: {pipeline}")
 
     def set_clickhouse_client(self, client: HttpClient) -> None:
@@ -91,6 +93,7 @@ class DynamicProcessor(object):
         rdefs = self.api.get_data_types()
         for rd in rdefs:
             self.resource_definitions["data_" + rd["name"]] = ResourceDefinition(rd)
+        self.resource_definitions_loaded_at = datetime.datetime.now()
 
     def build_message(self, value: dict, src_metadata: dict) -> list[dict[str, any]]:
         rdef = self._find_resource_definition(value)
@@ -128,6 +131,17 @@ class DynamicProcessor(object):
     # These are helper methods
 
     def _find_resource_definition(self, value: dict) -> ResourceDefinition | None:
+        # NOTE: We reload resource definitions every minute. This is kinda hacky and
+        # should be replaced in the future.
+        if (
+            datetime.datetime.now() - self.resource_definitions_loaded_at
+            > datetime.timedelta(minutes=1)
+        ):
+            rdefs = self.api.get_data_types()
+            for rd in rdefs:
+                self.resource_definitions["data_" + rd["name"]] = ResourceDefinition(rd)
+            self.resource_definitions_loaded_at = datetime.datetime.now()
+
         for rd in self.resource_definitions.values():
             if rd.applies_to(value):
                 return rd

--- a/metranova/processors/clickhouse/dynamic.py
+++ b/metranova/processors/clickhouse/dynamic.py
@@ -1,9 +1,11 @@
 import datetime
+import json
 import logging
 
 from metranova.processors.clickhouse.base import (
     BaseClickHouseMaterializedViewMixin,
 )
+from metranova.transformer import Transformer, TransformerColumn
 from clickhouse_connect.driver.httpclient import HttpClient
 
 logger = logging.getLogger(__name__)
@@ -25,6 +27,47 @@ class MetranovaSyncApi:
         except Exception as e:
             logger.exception(f"Error retrieving all resource types: {e}")
             return None
+
+    def get_transformers(self) -> list[Transformer]:
+        """Get all transformers and their columns from ClickHouse"""
+        try:
+            transformers = list(
+                self.client.query("SELECT * FROM metranova.transformer").named_results()
+            )
+            columns = list(
+                self.client.query(
+                    "SELECT * FROM metranova.transformer_column"
+                ).named_results()
+            )
+        except Exception as e:
+            logger.exception(f"Error retrieving transformers: {e}")
+            return []
+
+        cols_by_ref: dict[str, list[TransformerColumn]] = {}
+        for col in columns:
+            tc = TransformerColumn(
+                id=col["id"],
+                match_value=col["match_value"],
+                vendor_match_field=col["vendor_match_field"],
+                vendor_match_value=col["vendor_match_value"],
+                target_column=col["target_column"],
+                operation=col["operation"],
+                config=json.loads(col["config"]),
+                default_value=col["default_value"] or "",
+                order=col["order"],
+            )
+            cols_by_ref.setdefault(col["transformer_ref"], []).append(tc)
+
+        return [
+            Transformer(
+                id=t["id"],
+                name=t["name"],
+                match_field=t["match_field"],
+                definition_ref=t["definition_ref"],
+                columns=sorted(cols_by_ref.get(t["ref"], []), key=lambda c: c.order),
+            )
+            for t in transformers
+        ]
 
 
 class ResourceDefinition:
@@ -78,6 +121,7 @@ class DynamicProcessor(object):
         self.pipeline = pipeline
         self.resource_definitions = {}
         self.resource_definitions_loaded_at = None
+        self.transformers = {}
         logger.info(f"DynamicProcessor initialized with pipeline: {pipeline}")
 
     def set_clickhouse_client(self, client: HttpClient) -> None:
@@ -95,6 +139,8 @@ class DynamicProcessor(object):
             self.resource_definitions["data_" + rd["name"]] = ResourceDefinition(rd)
         self.resource_definitions_loaded_at = datetime.datetime.now()
 
+        self.transformers = {t.id: t for t in self.api.get_transformers()}
+
     def build_message(self, value: dict, src_metadata: dict) -> list[dict[str, any]]:
         rdef = self._find_resource_definition(value)
         if rdef is None:
@@ -102,6 +148,12 @@ class DynamicProcessor(object):
                 f"No matching resource definition found for message with fields: {value.get('fields', {})} and tags: {value.get('tags', {})}"
             )
             return None
+
+        for transformer in self.transformers.values():
+            for column in transformer.columns:
+                if column.match_value == src_metadata.get(transformer.match_field):
+                    column.apply(value)
+
         logger.info(f"Built message: {value} with metadata: {src_metadata}")
         return rdef.to_rows(value, src_metadata)
 
@@ -141,6 +193,8 @@ class DynamicProcessor(object):
             for rd in rdefs:
                 self.resource_definitions["data_" + rd["name"]] = ResourceDefinition(rd)
             self.resource_definitions_loaded_at = datetime.datetime.now()
+
+            self.transformers = {t.id: t for t in self.api.get_transformers()}
 
         for rd in self.resource_definitions.values():
             if rd.applies_to(value):

--- a/metranova/processors/clickhouse/dynamic.py
+++ b/metranova/processors/clickhouse/dynamic.py
@@ -76,7 +76,7 @@ class ResourceDefinition:
     _FIXED_COLUMNS = ["insert_time"]
 
     def __init__(self, definition: dict):
-        self._name: str = definition["name"]
+        self._name: str = definition["slug"]
         self._data_fields: list[dict] = definition.get("data_fields", [])
         self._required_field_names: list[str] = [
             f["field_name"] for f in self._data_fields if f["nullable"] is False
@@ -136,7 +136,7 @@ class DynamicProcessor(object):
 
         rdefs = self.api.get_data_types()
         for rd in rdefs:
-            self.resource_definitions["data_" + rd["name"]] = ResourceDefinition(rd)
+            self.resource_definitions["data_" + rd["slug"]] = ResourceDefinition(rd)
         self.resource_definitions_loaded_at = datetime.datetime.now()
 
         self.transformers = {t.id: t for t in self.api.get_transformers()}
@@ -191,7 +191,7 @@ class DynamicProcessor(object):
         ):
             rdefs = self.api.get_data_types()
             for rd in rdefs:
-                self.resource_definitions["data_" + rd["name"]] = ResourceDefinition(rd)
+                self.resource_definitions["data_" + rd["slug"]] = ResourceDefinition(rd)
             self.resource_definitions_loaded_at = datetime.datetime.now()
 
             self.transformers = {t.id: t for t in self.api.get_transformers()}

--- a/metranova/processors/clickhouse/dynamic.py
+++ b/metranova/processors/clickhouse/dynamic.py
@@ -1,0 +1,84 @@
+import logging
+import os
+import re
+from typing import Iterator
+from metranova.processors.clickhouse.base import (
+    BaseClickHouseMaterializedViewMixin,
+)
+
+import orjson
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class DynamicProcessor(object):
+    """Processor for handling user defined measurement types"""
+
+    def __init__(self, pipeline):
+        self.pipeline = pipeline
+        logger.error(f"DynamicProcessor initialized with pipeline: {pipeline}")
+
+    def match_message(self, value: dict) -> bool:
+        logger.error(f"Matching message for value: {value.values()}")
+        # load measurement types
+        return True
+
+    def scale_value(self, value, scale):
+        return value
+
+    def build_message(self, value: dict, src_metadata: dict) -> list[dict[str, any]]:
+        logger.error(
+            f"Building message for value: {value} with metadata: {src_metadata}"
+        )
+        return [
+            {"node": "example", "intf": "0/0/0", "rx_bytes": 1000, "tx_bytes": 2000}
+        ]
+
+    def has_match_field(self, value: dict) -> bool:
+        # load measurement types
+        logger.error(f"Checking match fields for value: {value.values()}")
+        return True
+
+    def has_required_fields(self, value: dict) -> bool:
+        # load measurement types.
+        return True
+
+    def get_ch_dictionaries(self) -> list:
+        return []
+
+    def get_materialized_views(self) -> list:
+        return []
+
+    def load_materialized_views(
+        self, env_var_name: str, mv_class: type[BaseClickHouseMaterializedViewMixin]
+    ) -> None:
+        return None
+
+    def get_ip_ref_extensions(self, env_var_name: str) -> list:
+        return []
+
+    def lookup_ip_ref_extensions(self, ip_address: str, direction: str) -> dict:
+        return {}
+
+    def column_names(self) -> list:
+        return []
+
+    def message_to_columns(self, message: dict, table_name: str) -> list:
+        return []
+
+    def get_table_names(self):
+        return []
+
+    def create_table_command(self, table_name=None) -> str:
+        return "SELECT 1"
+
+    def get_extension_defs(
+        self, env_var_name: str, extension_options: dict, json_column_name: str = "ext"
+    ) -> list:
+        return []
+
+    def extension_is_enabled(
+        self, extension_name: str, json_column_name: str = "ext"
+    ) -> bool:
+        return False

--- a/metranova/processors/clickhouse/dynamic.py
+++ b/metranova/processors/clickhouse/dynamic.py
@@ -179,7 +179,6 @@ class DynamicProcessor(object):
                 f"Error building message: Message resource type {msg_type} not a configured resource type {self.config.resource_types}, skipping message. This should not have happened!"
             )
             return None
-
         rdef = self._find_resource_definition(msg)
         if rdef is None:
             logger.error(
@@ -188,8 +187,11 @@ class DynamicProcessor(object):
             return None
 
         for transformer in self.transformers.values():
+            match_val = msg.get("tags", {}).get(transformer.match_field) or msg.get(
+                "fields", {}
+            ).get(transformer.match_field)
             for column in transformer.columns:
-                if column.match_value == src_metadata.get(transformer.match_field):
+                if column.match_value == match_val:
                     column.apply(msg)
 
         logger.info(f"Built message: {msg} with metadata: {src_metadata}")

--- a/metranova/writers/clickhouse.py
+++ b/metranova/writers/clickhouse.py
@@ -239,7 +239,9 @@ class ClickHouseBatcher:
             self.last_flush_time = time.time()
 
         except Exception as e:
-            self.logger.error(f"Failed to insert batch into ClickHouse: {e}")
+            self.logger.error(
+                f"Failed to insert batch into ClickHouse table {table_name}: {e}"
+            )
             self.logger.debug(f"table= {table_name}")
             self.logger.debug(
                 f"column_names= {self.processor.column_names(table_name=table_name)}"

--- a/metranova/writers/clickhouse.py
+++ b/metranova/writers/clickhouse.py
@@ -11,6 +11,7 @@ from metranova.writers.base import BaseWriter
 
 logger = logging.getLogger(__name__)
 
+
 class ClickHouseWriter(BaseWriter):
     def __init__(self, processors: List[BaseClickHouseProcessor]):
         super().__init__(processors)
@@ -36,26 +37,31 @@ class ClickHouseWriter(BaseWriter):
     def close(self):
         for batcher in self.batchers:
             batcher.close()
-        
+
         if self.datastore:
             self.datastore.close()
         logger.info("Datastore connection closed")
+
 
 class ClickHouseBatcher:
     def __init__(self, processor: BaseClickHouseProcessor):
         # Logger
         self.logger = logger
 
-        #Clickhouse Client and message processor
+        # Clickhouse Client and message processor
         # each batcher gets its own client to avoid threading issues
         self.client = ClickHouseConnector().client
         self.processor = processor
 
         # Batching configuration
-        self.batch_size = int(os.getenv('CLICKHOUSE_BATCH_SIZE', '1000'))
-        self.batch_timeout = float(os.getenv('CLICKHOUSE_BATCH_TIMEOUT', '30.0'))  # seconds
-        self.flush_interval = float(os.getenv('CLICKHOUSE_FLUSH_INTERVAL', '0.1'))  # seconds
-       
+        self.batch_size = int(os.getenv("CLICKHOUSE_BATCH_SIZE", "1000"))
+        self.batch_timeout = float(
+            os.getenv("CLICKHOUSE_BATCH_TIMEOUT", "30.0")
+        )  # seconds
+        self.flush_interval = float(
+            os.getenv("CLICKHOUSE_FLUSH_INTERVAL", "0.1")
+        )  # seconds
+
         # Batch state
         # self.batch is a dict where key is table name and value is list of messages for that table
         self.batch = defaultdict(list)
@@ -67,17 +73,19 @@ class ClickHouseBatcher:
             self.batch[table_name] = []
             self.create_table(table_name)
 
-        #create supporting dictionaries
+        # create supporting dictionaries
         for ch_dictionary in self.processor.get_ch_dictionaries():
             self.create_dictionary(ch_dictionary)
 
-        #create materialized views
+        # create materialized views
         for materialized_view in self.processor.get_materialized_views():
             self.create_materialized_view(materialized_view)
 
     def create_table(self, table_name):
         """Create the target table if it doesn't exist"""
-        create_table_cmd = self.processor.create_table_command(table_name=table_name) # store for reference
+        create_table_cmd = self.processor.create_table_command(
+            table_name=table_name
+        )  # store for reference
         if create_table_cmd is None:
             logger.info("No create_table_cmd defined, skipping table creation")
             return
@@ -92,13 +100,17 @@ class ClickHouseBatcher:
         """Create the target dictionary if it doesn't exist"""
         create_dict_cmd = ch_dictionary.create_dictionary_command()
         if create_dict_cmd is None:
-            logger.info("No create_dictionary_cmd defined, skipping dictionary creation")
+            logger.info(
+                "No create_dictionary_cmd defined, skipping dictionary creation"
+            )
             return
         try:
             self.client.command(create_dict_cmd)
             logger.info(f"Dictionary {ch_dictionary.dictionary_name} is ready")
         except Exception as e:
-            logger.error(f"Failed to create dictionary {ch_dictionary.dictionary_name}: {e}")
+            logger.error(
+                f"Failed to create dictionary {ch_dictionary.dictionary_name}: {e}"
+            )
             raise
 
     def create_materialized_view(self, materialized_view):
@@ -110,34 +122,45 @@ class ClickHouseBatcher:
             return
         create_mv_cmd = materialized_view.create_mv_command()
         if create_mv_cmd is None:
-            logger.info("No create_materialized_view_cmd defined, skipping materialized view creation")
+            logger.info(
+                "No create_materialized_view_cmd defined, skipping materialized view creation"
+            )
             return
         # Create the target table
         try:
-            self.logger.debug(f"Creating materialized view target table with command: {create_table_cmd}")
+            self.logger.debug(
+                f"Creating materialized view target table with command: {create_table_cmd}"
+            )
             self.client.command(create_table_cmd)
             logger.info(f"Materialized View Table {materialized_view.table} is ready")
         except Exception as e:
-            logger.error(f"Failed to create materialized view target table {materialized_view.table}: {e}")
+            logger.error(
+                f"Failed to create materialized view target table {materialized_view.table}: {e}"
+            )
             raise
         # Create materialized view
         try:
-            self.logger.debug(f"Creating materialized view with command: {create_mv_cmd}")
+            self.logger.debug(
+                f"Creating materialized view with command: {create_mv_cmd}"
+            )
             self.client.command(create_mv_cmd)
             logger.info(f"Materialized View {materialized_view.mv_name} is ready")
         except Exception as e:
-            logger.error(f"Failed to create materialized view {materialized_view.mv_name}: {e}")
+            logger.error(
+                f"Failed to create materialized view {materialized_view.mv_name}: {e}"
+            )
             raise
 
     def start_flush_timer(self):
         """Start background timer to flush batches periodically"""
+
         def flush_timer():
             while True:
-                # Check every flush_interval seconds. 
+                # Check every flush_interval seconds.
                 # Note that max clickhouse throughput is self.flush_interval * self.batch_size
-                time.sleep(self.flush_interval)  
+                time.sleep(self.flush_interval)
                 current_time = time.time()
-                
+
                 with self.batch_lock:
                     if (current_time - self.last_flush_time) >= self.batch_timeout:
                         for table_name in self.batch:
@@ -151,7 +174,7 @@ class ClickHouseBatcher:
         """Add message to batch and flush if needed"""
         if not msg:
             return
-        
+
         # Check if this processor should handle the message
         if not self.processor.match_message(msg):
             self.logger.debug("Message did not match processor criteria, skipping")
@@ -161,14 +184,16 @@ class ClickHouseBatcher:
         message_data = self.processor.build_message(msg, consumer_metadata)
         if message_data is None:
             return
-        
-        #append to batch
+
+        # append to batch
         with self.batch_lock:
-            #Note: message_data is a list of dicts so += adds all elements
+            # Note: message_data is a list of dicts so += adds all elements
             for formatted_msg in message_data:
-                table_name = formatted_msg.get('_clickhouse_table', self.processor.table)
+                table_name = formatted_msg.get(
+                    "_clickhouse_table", self.processor.table
+                )
                 self.batch[table_name].append(formatted_msg)
-            
+
             # Check if we need to flush
             for table_name in self.batch:
                 if len(self.batch[table_name]) >= self.batch_size:
@@ -177,37 +202,41 @@ class ClickHouseBatcher:
     def flush_batch(self, table_name):
         """Flush current batch to ClickHouse"""
         if not self.batch or not table_name or not self.batch.get(table_name, None):
-            #nothing to flush
+            # nothing to flush
             return
-        
+
         try:
             # Prepare data for insertion
             data_to_insert = []
             for msg in self.batch[table_name]:
-                data_to_insert.append(self.processor.message_to_columns(msg, table_name))
-            
+                data_to_insert.append(
+                    self.processor.message_to_columns(msg, table_name)
+                )
+
             # Insert batch into ClickHouse
             self.client.insert(
                 table=table_name,
                 data=data_to_insert,
-                column_names=self.processor.column_names()
+                column_names=self.processor.column_names(),
             )
 
-            self.logger.debug(f"Successfully inserted {len(data_to_insert)} messages into ClickHouse table {table_name}")
-            
+            self.logger.debug(
+                f"Successfully inserted {len(data_to_insert)} messages into ClickHouse table {table_name}"
+            )
+
             # Clear batch and update flush time
             self.batch[table_name].clear()
             self.last_flush_time = time.time()
-            
+
         except Exception as e:
             self.logger.error(f"Failed to insert batch into ClickHouse: {e}")
             self.logger.debug(f"table= {table_name}")
             self.logger.debug(f"column_names= {self.processor.column_names()}")
             self.logger.debug(f"data_to_insert= {data_to_insert}")
-    
+            self.last_flush_time = time.time()
+
     def close(self):
         with self.batch_lock:
             for table_name in self.batch:
                 self.logger.info("Flushing remaining messages before closing...")
                 self.flush_batch(table_name)
-

--- a/metranova/writers/clickhouse.py
+++ b/metranova/writers/clickhouse.py
@@ -221,7 +221,7 @@ class ClickHouseBatcher:
 
             # Insert batch into ClickHouse
             column_names = self.processor.column_names(table_name=table_name)
-            logger.info(
+            self.logger.debug(
                 f"Table: {table_name}, Data: {str(data_to_insert)}, Columns: {str(column_names)}"
             )
             self.client.insert(

--- a/metranova/writers/clickhouse.py
+++ b/metranova/writers/clickhouse.py
@@ -80,6 +80,8 @@ class ClickHouseBatcher:
         # create materialized views
         for materialized_view in self.processor.get_materialized_views():
             self.create_materialized_view(materialized_view)
+        
+        self.processor.set_clickhouse_client(self.client)
 
     def create_table(self, table_name):
         """Create the target table if it doesn't exist"""

--- a/metranova/writers/clickhouse.py
+++ b/metranova/writers/clickhouse.py
@@ -80,7 +80,7 @@ class ClickHouseBatcher:
         # create materialized views
         for materialized_view in self.processor.get_materialized_views():
             self.create_materialized_view(materialized_view)
-        
+
         self.processor.set_clickhouse_client(self.client)
 
     def create_table(self, table_name):
@@ -194,6 +194,10 @@ class ClickHouseBatcher:
                 table_name = formatted_msg.get(
                     "_clickhouse_table", self.processor.table
                 )
+                if "_clickhouse_table" in formatted_msg:
+                    del formatted_msg[
+                        "_clickhouse_table"
+                    ]  # remove table name from message before insertion
                 self.batch[table_name].append(formatted_msg)
 
             # Check if we need to flush
@@ -216,10 +220,14 @@ class ClickHouseBatcher:
                 )
 
             # Insert batch into ClickHouse
+            column_names = self.processor.column_names(table_name=table_name)
+            logger.info(
+                f"Table: {table_name}, Data: {str(data_to_insert)}, Columns: {str(column_names)}"
+            )
             self.client.insert(
                 table=table_name,
                 data=data_to_insert,
-                column_names=self.processor.column_names(),
+                column_names=column_names,
             )
 
             self.logger.debug(
@@ -233,7 +241,9 @@ class ClickHouseBatcher:
         except Exception as e:
             self.logger.error(f"Failed to insert batch into ClickHouse: {e}")
             self.logger.debug(f"table= {table_name}")
-            self.logger.debug(f"column_names= {self.processor.column_names()}")
+            self.logger.debug(
+                f"column_names= {self.processor.column_names(table_name=table_name)}"
+            )
             self.logger.debug(f"data_to_insert= {data_to_insert}")
             self.last_flush_time = time.time()
 

--- a/pipelines/data_dynamic.yml
+++ b/pipelines/data_dynamic.yml
@@ -1,0 +1,7 @@
+consumers:
+  - type: metranova.consumers.kafka.KafkaConsumer
+
+writers:
+  - type: metranova.writers.clickhouse.ClickHouseWriter
+    processors:
+      - metranova.processors.clickhouse.dynamic.DynamicProcessor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 
 [tool.uv.sources]
 metranova = { workspace = true }
-metranova-core = { git = "https://github.com/MetrANOVA/api.git", subdirectory = "packages/metranova", branch = "main" }
+metranova-core = { git = "https://github.com/MetrANOVA/api.git", subdirectory = "packages/metranova", branch = "js-transformers" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["metranova"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "cachetools==6.2.1",
     "clickhouse-connect==0.15.0",
     "confluent-kafka==2.14.0",
+    "metranova-core",
     "orjson==3.11.3",
     "pycountry==24.6.1",
     "pycountry-convert==0.7.2",
@@ -18,7 +19,8 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-metranova_core = { workspace = true }
+metranova = { workspace = true }
+metranova-core = { git = "https://github.com/MetrANOVA/api.git", subdirectory = "packages/metranova", branch = "js-shared-lib2" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["metranova"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 
 [tool.uv.sources]
 metranova = { workspace = true }
-metranova-core = { git = "https://github.com/MetrANOVA/api.git", subdirectory = "packages/metranova", branch = "js-shared-lib2" }
+metranova-core = { git = "https://github.com/MetrANOVA/api.git", subdirectory = "packages/metranova", branch = "main" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["metranova"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 
 [tool.uv.sources]
 metranova = { workspace = true }
-metranova-core = { git = "https://github.com/MetrANOVA/api.git", subdirectory = "packages/metranova", branch = "js-transformers" }
+metranova-core = { git = "https://github.com/MetrANOVA/api.git", subdirectory = "packages/metranova", branch = "main" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["metranova"]

--- a/test/processors/clickhouse/test_dynamic.py
+++ b/test/processors/clickhouse/test_dynamic.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python3
+
+import datetime
+import unittest
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+# Add the project root to Python path for imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
+
+from metranova.processors.clickhouse import dynamic as dynamic_module
+from metranova.processors.clickhouse.dynamic import (
+    ResourceDefinition,
+    MetranovaSyncApi,
+    DynamicProcessorConfig,
+    DynamicProcessor,
+)
+from metranova.transformer import Transformer, TransformerColumn
+
+
+def _make_rdef(slug, data_fields):
+    """Build a ResourceDefinition from a slug and list of (field_name, nullable) tuples."""
+    return ResourceDefinition({
+        "slug": slug,
+        "data_fields": [
+            {"field_name": n, "nullable": nullable} for n, nullable in data_fields
+        ],
+    })
+
+
+def _mock_ch_client(definition_rows=None, transformer_rows=None, transformer_column_rows=None):
+    """Build a mock HttpClient whose .query(sql).named_results() returns the requested rows."""
+    client = MagicMock()
+
+    def query_side_effect(sql):
+        result = MagicMock()
+        if "metranova.definition" in sql:
+            result.named_results.return_value = definition_rows or []
+        elif "metranova.transformer_column" in sql:
+            result.named_results.return_value = transformer_column_rows or []
+        elif "metranova.transformer" in sql:
+            result.named_results.return_value = transformer_rows or []
+        else:
+            result.named_results.return_value = []
+        return result
+
+    client.query.side_effect = query_side_effect
+    return client
+
+
+class TestResourceDefinition(unittest.TestCase):
+    def test_table_name_prefixes_with_data_(self):
+        rdef = _make_rdef("interface", [("ifindex", False)])
+        self.assertEqual(rdef.table_name, "data_interface")
+
+    def test_columns_includes_data_fields_and_insert_time(self):
+        rdef = _make_rdef("interface", [("ifindex", False), ("speed", True)])
+        self.assertEqual(rdef.columns(), ["ifindex", "speed", "insert_time"])
+
+    def test_required_field_names_only_includes_non_nullable(self):
+        rdef = _make_rdef(
+            "interface",
+            [("ifindex", False), ("speed", True), ("name", False)],
+        )
+        self.assertEqual(rdef._required_field_names, ["ifindex", "name"])
+
+    def test_applies_to_matches_default_name_field(self):
+        rdef = _make_rdef("interface", [("ifindex", False)])
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(rdef.applies_to({"name": "interface"}))
+            self.assertFalse(rdef.applies_to({"name": "cpu"}))
+
+    def test_applies_to_uses_env_override_field(self):
+        rdef = _make_rdef("interface", [("ifindex", False)])
+        with patch.dict(os.environ, {"PROCESSOR_DYNAMIC_RESOURCE_TYPE_FIELD_NAME": "measurement"}):
+            self.assertTrue(rdef.applies_to({"measurement": "interface"}))
+            self.assertFalse(rdef.applies_to({"name": "interface"}))
+
+    def test_to_rows_pulls_from_fields_then_tags(self):
+        rdef = _make_rdef("interface", [("ifindex", False), ("device_id", True), ("missing", True)])
+        message = {
+            "fields": {"ifindex": 42},
+            "tags": {"device_id": "router-01"},
+            "timestamp": 1234567890,
+        }
+        rows = rdef.to_rows(message, {})
+        row = rows[0]
+        self.assertEqual(row["ifindex"], 42)
+        self.assertEqual(row["device_id"], "router-01")
+        self.assertIsNone(row["missing"])
+
+    def test_to_rows_sets_insert_time_from_message_timestamp(self):
+        rdef = _make_rdef("interface", [("ifindex", False)])
+        rows = rdef.to_rows({"fields": {"ifindex": 1}, "timestamp": 999}, {})
+        self.assertEqual(rows[0]["insert_time"], 999)
+
+    def test_to_rows_includes_clickhouse_table_marker(self):
+        rdef = _make_rdef("interface", [("ifindex", False)])
+        rows = rdef.to_rows({"fields": {"ifindex": 1}, "timestamp": 0}, {})
+        self.assertEqual(rows[0]["_clickhouse_table"], "data_interface")
+
+    def test_to_rows_returns_list_with_single_row(self):
+        rdef = _make_rdef("interface", [("ifindex", False)])
+        rows = rdef.to_rows({"fields": {"ifindex": 1}, "timestamp": 0}, {})
+        self.assertIsInstance(rows, list)
+        self.assertEqual(len(rows), 1)
+
+    def test_to_rows_handles_missing_fields_and_tags_keys(self):
+        rdef = _make_rdef("interface", [("ifindex", False), ("speed", True)])
+        rows = rdef.to_rows({"timestamp": 0}, {})
+        row = rows[0]
+        self.assertIsNone(row["ifindex"])
+        self.assertIsNone(row["speed"])
+
+
+class TestDynamicProcessorConfig(unittest.TestCase):
+    def test_defaults_when_no_env_vars(self):
+        with patch.dict(os.environ, {}, clear=True):
+            config = DynamicProcessorConfig()
+        self.assertEqual(config.resource_types, set())
+        self.assertEqual(config.resource_type_field_name, "name")
+
+    def test_resource_types_parses_comma_separated_list(self):
+        with patch.dict(os.environ, {"PROCESSOR_DYNAMIC_RESOURCE_TYPES": "interface,cpu,memory"}):
+            config = DynamicProcessorConfig()
+        self.assertEqual(config.resource_types, {"interface", "cpu", "memory"})
+
+    def test_resource_types_empty_string_yields_empty_set(self):
+        with patch.dict(os.environ, {"PROCESSOR_DYNAMIC_RESOURCE_TYPES": ""}):
+            config = DynamicProcessorConfig()
+        self.assertEqual(config.resource_types, set())
+
+    def test_resource_type_field_name_override(self):
+        with patch.dict(os.environ, {"PROCESSOR_DYNAMIC_RESOURCE_TYPE_FIELD_NAME": "measurement"}):
+            config = DynamicProcessorConfig()
+        self.assertEqual(config.resource_type_field_name, "measurement")
+
+
+class TestMetranovaSyncApi(unittest.TestCase):
+    def test_get_data_types_returns_resource_definitions(self):
+        rows = [
+            {"slug": "interface", "data_fields": [{"field_name": "ifindex", "nullable": False}]},
+            {"slug": "cpu", "data_fields": [{"field_name": "load", "nullable": False}]},
+        ]
+        client = _mock_ch_client(definition_rows=rows)
+        api = MetranovaSyncApi(client)
+        result = api.get_data_types()
+        self.assertEqual(len(result), 2)
+        self.assertEqual({r._slug for r in result}, {"interface", "cpu"})
+
+    def test_get_data_types_returns_empty_on_query_exception(self):
+        client = MagicMock()
+        client.query.side_effect = Exception("boom")
+        api = MetranovaSyncApi(client)
+        with patch.object(dynamic_module.logger, "exception") as mock_log:
+            result = api.get_data_types()
+        self.assertEqual(result, [])
+        mock_log.assert_called_once()
+
+    def test_get_transformers_joins_columns_to_transformers_by_ref(self):
+        transformer_rows = [{
+            "id": "t1",
+            "ref": "ref-1",
+            "name": "vendor-transformer",
+            "match_field": "vendor",
+            "definition_ref": "def-1",
+        }]
+        column_rows = [
+            {
+                "id": "c2",
+                "transformer_ref": "ref-1",
+                "match_value": "vendor-a",
+                "vendor_match_field": None,
+                "vendor_match_value": None,
+                "target_column": "label",
+                "operation": "static",
+                "config": '{"value": "B"}',
+                "default_value": "",
+                "order": 2,
+            },
+            {
+                "id": "c1",
+                "transformer_ref": "ref-1",
+                "match_value": "vendor-a",
+                "vendor_match_field": None,
+                "vendor_match_value": None,
+                "target_column": "label",
+                "operation": "static",
+                "config": '{"value": "A"}',
+                "default_value": "",
+                "order": 1,
+            },
+        ]
+        client = _mock_ch_client(
+            transformer_rows=transformer_rows,
+            transformer_column_rows=column_rows,
+        )
+        api = MetranovaSyncApi(client)
+        transformers = api.get_transformers()
+        self.assertEqual(len(transformers), 1)
+        ordered_ids = [c.id for c in transformers[0].columns]
+        self.assertEqual(ordered_ids, ["c1", "c2"])
+
+    def test_get_transformers_handles_null_default_value(self):
+        transformer_rows = [{
+            "id": "t1",
+            "ref": "ref-1",
+            "name": "x",
+            "match_field": "vendor",
+            "definition_ref": "def-1",
+        }]
+        column_rows = [{
+            "id": "c1",
+            "transformer_ref": "ref-1",
+            "match_value": "v",
+            "vendor_match_field": None,
+            "vendor_match_value": None,
+            "target_column": "col",
+            "operation": "static",
+            "config": "{}",
+            "default_value": None,
+            "order": 0,
+        }]
+        client = _mock_ch_client(
+            transformer_rows=transformer_rows,
+            transformer_column_rows=column_rows,
+        )
+        api = MetranovaSyncApi(client)
+        transformers = api.get_transformers()
+        self.assertEqual(transformers[0].columns[0].default_value, "")
+
+    def test_get_transformers_with_no_columns_for_transformer(self):
+        transformer_rows = [{
+            "id": "t1",
+            "ref": "ref-1",
+            "name": "x",
+            "match_field": "vendor",
+            "definition_ref": "def-1",
+        }]
+        client = _mock_ch_client(transformer_rows=transformer_rows, transformer_column_rows=[])
+        api = MetranovaSyncApi(client)
+        transformers = api.get_transformers()
+        self.assertEqual(transformers[0].columns, [])
+
+    def test_get_transformers_returns_empty_on_query_exception(self):
+        client = MagicMock()
+        client.query.side_effect = Exception("boom")
+        api = MetranovaSyncApi(client)
+        with patch.object(dynamic_module.logger, "exception") as mock_log:
+            result = api.get_transformers()
+        self.assertEqual(result, [])
+        mock_log.assert_called_once()
+
+    def test_get_transformers_parses_config_json(self):
+        transformer_rows = [{
+            "id": "t1",
+            "ref": "ref-1",
+            "name": "x",
+            "match_field": "vendor",
+            "definition_ref": "def-1",
+        }]
+        column_rows = [{
+            "id": "c1",
+            "transformer_ref": "ref-1",
+            "match_value": "v",
+            "vendor_match_field": None,
+            "vendor_match_value": None,
+            "target_column": "col",
+            "operation": "static",
+            "config": '{"foo": "bar"}',
+            "default_value": "",
+            "order": 0,
+        }]
+        client = _mock_ch_client(
+            transformer_rows=transformer_rows,
+            transformer_column_rows=column_rows,
+        )
+        api = MetranovaSyncApi(client)
+        transformers = api.get_transformers()
+        self.assertEqual(transformers[0].columns[0].config, {"foo": "bar"})
+
+
+class TestDynamicProcessor(unittest.TestCase):
+    def setUp(self):
+        """Set up test fixtures before each test method."""
+        self.mock_pipeline = MagicMock()
+        with patch.dict(os.environ, {}, clear=True):
+            self.processor = DynamicProcessor(self.mock_pipeline)
+
+        self.rdef_interface = _make_rdef(
+            "interface",
+            [("ifindex", False), ("speed", True)],
+        )
+        self.processor.resource_definitions = {"data_interface": self.rdef_interface}
+        self.processor.resource_definitions_loaded_at = datetime.datetime.now()
+        self.processor.api = MagicMock()
+
+    # Initialization
+
+    def test_init_sets_empty_caches_and_config(self):
+        with patch.dict(os.environ, {}, clear=True):
+            proc = DynamicProcessor(self.mock_pipeline)
+        self.assertEqual(proc.resource_definitions, {})
+        self.assertIsNone(proc.resource_definitions_loaded_at)
+        self.assertEqual(proc.transformers, {})
+        self.assertIsInstance(proc.config, DynamicProcessorConfig)
+
+    # set_clickhouse_client
+
+    def test_set_clickhouse_client_loads_definitions_and_transformers(self):
+        definition_rows = [{
+            "slug": "interface",
+            "data_fields": [{"field_name": "ifindex", "nullable": False}],
+        }]
+        transformer_rows = [{
+            "id": "t1",
+            "ref": "ref-1",
+            "name": "x",
+            "match_field": "vendor",
+            "definition_ref": "def-1",
+        }]
+        column_rows = [{
+            "id": "c1",
+            "transformer_ref": "ref-1",
+            "match_value": "v",
+            "vendor_match_field": None,
+            "vendor_match_value": None,
+            "target_column": "col",
+            "operation": "static",
+            "config": "{}",
+            "default_value": "",
+            "order": 0,
+        }]
+        client = _mock_ch_client(
+            definition_rows=definition_rows,
+            transformer_rows=transformer_rows,
+            transformer_column_rows=column_rows,
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            proc = DynamicProcessor(self.mock_pipeline)
+        proc.set_clickhouse_client(client)
+        self.assertIn("data_interface", proc.resource_definitions)
+        self.assertIn("t1", proc.transformers)
+        self.assertIsInstance(proc.resource_definitions_loaded_at, datetime.datetime)
+        self.assertIsInstance(proc.api, MetranovaSyncApi)
+
+    # match_message
+
+    def test_match_message_returns_true_for_known_type(self):
+        self.assertTrue(self.processor.match_message({"name": "interface"}))
+
+    def test_match_message_returns_false_when_resource_type_field_missing(self):
+        self.assertFalse(self.processor.match_message({"fields": {}}))
+
+    def test_match_message_returns_false_when_type_not_in_configured_set(self):
+        self.processor.config.resource_types = {"cpu"}
+        self.assertFalse(self.processor.match_message({"name": "interface"}))
+
+    def test_match_message_returns_true_when_configured_set_empty(self):
+        self.processor.config.resource_types = set()
+        self.assertTrue(self.processor.match_message({"name": "interface"}))
+
+    def test_match_message_returns_false_when_no_resource_definition_found(self):
+        self.assertFalse(self.processor.match_message({"name": "unknown"}))
+
+    # build_message
+
+    def test_build_message_returns_none_when_resource_type_missing(self):
+        self.assertIsNone(self.processor.build_message({"fields": {}}, {}))
+
+    def test_build_message_returns_none_when_type_not_in_configured_set(self):
+        self.processor.config.resource_types = {"cpu"}
+        self.assertIsNone(self.processor.build_message({"name": "interface"}, {}))
+
+    def test_build_message_returns_none_when_no_resource_definition(self):
+        self.assertIsNone(self.processor.build_message({"name": "unknown"}, {}))
+
+    def test_build_message_produces_row_with_clickhouse_table_marker(self):
+        msg = {
+            "name": "interface",
+            "fields": {"ifindex": 7, "speed": 1000},
+            "timestamp": 1234,
+        }
+        rows = self.processor.build_message(msg, {})
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["ifindex"], 7)
+        self.assertEqual(row["speed"], 1000)
+        self.assertEqual(row["insert_time"], 1234)
+        self.assertEqual(row["_clickhouse_table"], "data_interface")
+
+    def test_build_message_applies_matching_transformer_columns(self):
+        rdef = _make_rdef(
+            "interface",
+            [("ifindex", False), ("vendor_label", True)],
+        )
+        self.processor.resource_definitions = {"data_interface": rdef}
+        column = TransformerColumn(
+            id="c1",
+            match_value="vendor-a",
+            target_column="vendor_label",
+            operation="static",
+            config={"value": "X"},
+        )
+        transformer = Transformer(
+            id="t1",
+            name="vendor-transformer",
+            match_field="vendor",
+            definition_ref="def-1",
+            columns=[column],
+        )
+        self.processor.transformers = {transformer.id: transformer}
+
+        msg = {"name": "interface", "fields": {"ifindex": 1}, "timestamp": 0}
+        rows = self.processor.build_message(msg, {"vendor": "vendor-a"})
+        self.assertEqual(rows[0]["vendor_label"], "X")
+
+    def test_build_message_skips_transformer_columns_with_non_matching_value(self):
+        rdef = _make_rdef(
+            "interface",
+            [("ifindex", False), ("vendor_label", True)],
+        )
+        self.processor.resource_definitions = {"data_interface": rdef}
+        column = TransformerColumn(
+            id="c1",
+            match_value="vendor-a",
+            target_column="vendor_label",
+            operation="static",
+            config={"value": "X"},
+        )
+        transformer = Transformer(
+            id="t1",
+            name="vendor-transformer",
+            match_field="vendor",
+            definition_ref="def-1",
+            columns=[column],
+        )
+        self.processor.transformers = {transformer.id: transformer}
+
+        msg = {"name": "interface", "fields": {"ifindex": 1}, "timestamp": 0}
+        rows = self.processor.build_message(msg, {"vendor": "vendor-b"})
+        self.assertIsNone(rows[0]["vendor_label"])
+
+    def test_build_message_skips_transformer_columns_when_match_field_absent_from_metadata(self):
+        rdef = _make_rdef(
+            "interface",
+            [("ifindex", False), ("vendor_label", True)],
+        )
+        self.processor.resource_definitions = {"data_interface": rdef}
+        column = TransformerColumn(
+            id="c1",
+            match_value="vendor-a",
+            target_column="vendor_label",
+            operation="static",
+            config={"value": "X"},
+        )
+        transformer = Transformer(
+            id="t1",
+            name="vendor-transformer",
+            match_field="vendor",
+            definition_ref="def-1",
+            columns=[column],
+        )
+        self.processor.transformers = {transformer.id: transformer}
+
+        msg = {"name": "interface", "fields": {"ifindex": 1}, "timestamp": 0}
+        rows = self.processor.build_message(msg, {})
+        self.assertIsNone(rows[0]["vendor_label"])
+
+    # column_names
+
+    def test_column_names_returns_definition_columns(self):
+        self.assertEqual(
+            self.processor.column_names("data_interface"),
+            ["ifindex", "speed", "insert_time"],
+        )
+
+    def test_column_names_returns_empty_list_for_unknown_table(self):
+        with patch.object(dynamic_module.logger, "warning") as mock_warning:
+            result = self.processor.column_names("data_unknown")
+        self.assertEqual(result, [])
+        mock_warning.assert_called_once()
+
+    # Interface stubs
+
+    def test_get_ch_dictionaries_returns_empty_list(self):
+        self.assertEqual(self.processor.get_ch_dictionaries(), [])
+
+    def test_get_ip_ref_extensions_returns_empty_list(self):
+        self.assertEqual(self.processor.get_ip_ref_extensions("ANY_ENV_VAR"), [])
+
+    def test_lookup_ip_ref_extensions_returns_empty_dict(self):
+        self.assertEqual(self.processor.lookup_ip_ref_extensions("1.2.3.4", "src"), {})
+
+    def test_get_extension_defs_returns_empty_list(self):
+        self.assertEqual(self.processor.get_extension_defs("ENV", {}), [])
+
+    def test_extension_is_enabled_returns_false(self):
+        self.assertFalse(self.processor.extension_is_enabled("any_ext"))
+
+    def test_get_materialized_views_returns_empty_list(self):
+        self.assertEqual(self.processor.get_materialized_views(), [])
+
+    def test_get_table_names_returns_empty_list(self):
+        self.assertEqual(self.processor.get_table_names(), [])
+
+    def test_create_table_command_returns_select_1(self):
+        self.assertEqual(self.processor.create_table_command(), "SELECT 1")
+        self.assertEqual(self.processor.create_table_command("any_name"), "SELECT 1")
+
+    def test_table_property_returns_invalid_table_sentinel(self):
+        self.assertEqual(self.processor.table, "invalid_table")
+
+    def test_has_match_field_returns_true(self):
+        self.assertTrue(self.processor.has_match_field({}))
+
+    def test_has_required_fields_returns_true(self):
+        self.assertTrue(self.processor.has_required_fields({}))
+
+    def test_load_materialized_views_returns_none(self):
+        self.assertIsNone(self.processor.load_materialized_views("ANY_ENV", object))
+
+    def test_message_to_columns_returns_dict_values_as_list(self):
+        result = self.processor.message_to_columns({"a": 1, "b": 2}, "data_interface")
+        self.assertEqual(result, [1, 2])
+
+    def test_scale_value_returns_value_unchanged(self):
+        self.assertEqual(self.processor.scale_value(42, 1000), 42)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,1144 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "6.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/7e/b975b5814bd36faf009faebe22c1072a1fa1168db34d285ef0ba071ad78c/cachetools-6.2.1.tar.gz", hash = "sha256:3f391e4bd8f8bf0931169baf7456cc822705f4e2a31f840d218f445b9a854201", size = 31325, upload-time = "2025-10-12T14:55:30.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/c5/1e741d26306c42e2bf6ab740b2202872727e0f606033c9dd713f8b93f5a8/cachetools-6.2.1-py3-none-any.whl", hash = "sha256:09868944b6dde876dfd44e1d47e18484541eaf12f26f29b7af91b26cc892d701", size = 11280, upload-time = "2025-10-12T14:55:28.382Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "clickhouse-connect"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "lz4" },
+    { name = "pytz" },
+    { name = "urllib3" },
+    { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/59/c0b0a2c2e4c204e5baeca4917a95cc95add651da3cec86ec464a8e54cfa0/clickhouse_connect-0.15.0.tar.gz", hash = "sha256:529fcf072df335d18ae16339d99389190f4bd543067dcdc174541c7a9c622ef5", size = 126344, upload-time = "2026-03-26T18:34:52.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/90/ec2343a5d748d4c008f3c0bd66040a912ea42dd67f95997ecf1be267b56e/clickhouse_connect-0.15.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:782495f7a20a95ec73fe0c007f5f640fcc5aef621bfdfe9fd8c5dd4a2cbdc837", size = 285170, upload-time = "2026-03-26T18:33:54.456Z" },
+    { url = "https://files.pythonhosted.org/packages/88/06/5a1af09dfb0a487b7fcd984819a971ae42efb13d51a32b8671181e11958e/clickhouse_connect-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5e0286e33c7492f1fc7f194a5d1c124a60ac70479100d7b563466d1701d604e4", size = 276855, upload-time = "2026-03-26T18:33:55.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/31/4871cfb99faf27c41dea9a56be863df70d5394d10affb51dcc4fb0c08f1b/clickhouse_connect-0.15.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9b13f959aa20be73bc7341e8922d72981a07d38df55dbfa2c8a2bb7163847a2", size = 1089062, upload-time = "2026-03-26T18:33:57.255Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/6c/9d56f69b82506e5d66246d018d38997c9a0c48b70efde36c370cec343652/clickhouse_connect-0.15.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:384402746d943d27c12a4929b5ddb7fb45b4ac7ee2d5ed53326ef2c10cc4a782", size = 1100790, upload-time = "2026-03-26T18:33:58.732Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8e/331a0f957ffcec5688c175ca90c7ae3e8158e47814748bac777942d4203f/clickhouse_connect-0.15.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:de5f31818adcfa7fa4c8a7f102d0aaa2c68730771f3627fc19fb1536069d1ca2", size = 1072487, upload-time = "2026-03-26T18:34:00.413Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/03/87ee4a6586e0503b84a7223ad4ee051f6ad9a37a4a0d0838106bd2cee031/clickhouse_connect-0.15.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9b96619f2bd24b183e6d8de04e56659ee6ccaadc393ee1d50fe39f08f85ff58f", size = 1097169, upload-time = "2026-03-26T18:34:02.381Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/65/9e6798e2f4dcf40945dbcd76b94d9f9cee504066354b3f31287221b55156/clickhouse_connect-0.15.0-cp314-cp314-win32.whl", hash = "sha256:e33a985a5f043819839e84a0c46aec54bee1df55d2d1a302e709680c630d8142", size = 259505, upload-time = "2026-03-26T18:34:04.31Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/60/f49bc4e18b21e48d374fee310452a570f2837287f139f5d5e5006c96cd5d/clickhouse_connect-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:38c7c12e125788455cfd4c7639f54a72fba65c7660a8d2610eaef6153644188f", size = 278105, upload-time = "2026-03-26T18:34:05.898Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/2b/e10b6de7b8d60b25e6fe18b3f2feedfdc1c3132801ecb5b89e216a640273/clickhouse_connect-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ddd2081c2cd0d99c3359334482fa87f8139c8965d6b86c1bf8ca7864e4f83a0c", size = 298053, upload-time = "2026-03-26T18:34:07.605Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/54/7fda06e0ca8802c139214a4b6937aadef3776017cb6c1fa487b5b69788c8/clickhouse_connect-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:21a8cc777c8892dfa5e403c7034b5872029a5b34ab400ca3414db963310c35e2", size = 292617, upload-time = "2026-03-26T18:34:09.189Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c2/1df0167fb9363793c7e8dba8def9da07a85903eec58cd73657a137756f50/clickhouse_connect-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3801fff69ef0fb0899f0f28ef0aaa45d525840822ace6bcdde70cbb3426a6ce0", size = 1170408, upload-time = "2026-03-26T18:34:11.153Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/c97807fd7f34c978f0c7d6feabc39398d86db12e3ea0490dec1fc074c8ec/clickhouse_connect-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c0eed97e1973cca6771c61415b39c081e7b771766991208f9fe9375237bf29e", size = 1148855, upload-time = "2026-03-26T18:34:12.798Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2f/e76ec6c5aab54a13be8c5fc025652d41ad969fea46b9dc1da6af61bd19d0/clickhouse_connect-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:00d3bfe0f2a6e1da6b5bc48b93ee19234e359f086c3173a45e53a9f3070b849a", size = 1131149, upload-time = "2026-03-26T18:34:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/91/90/3b0900bf37d747ba3658c42788d595f58345b7dd32cdb48153afa50fe0e3/clickhouse_connect-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eabf45583a2e0a50e797ab4c6b7896d4fd46a584d28101ebeb47b3a8e2509a22", size = 1138555, upload-time = "2026-03-26T18:34:16.672Z" },
+    { url = "https://files.pythonhosted.org/packages/db/0b/122c24acdaa5593b535b25d0c4f6a5b9cac677451d849d4d145b057fd527/clickhouse_connect-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:8a038308ed2d85210a9981466cc47470b207605b9712aea45345bcf1155bd352", size = 281845, upload-time = "2026-03-26T18:34:18.302Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/ea2fd24535d392b20acca55c786409be7f9017d3339b562954cdd7656971/clickhouse_connect-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:18a31347366afc5a61e2864c4ce3c1398d792aad62ac72bd2672534580b3c9d6", size = 305507, upload-time = "2026-03-26T18:34:19.989Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "confluent-kafka"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/52/2c71d8e0b2de51076f90cea05342dc9c20fa14ded11992827680db4bbdfa/confluent_kafka-2.14.0.tar.gz", hash = "sha256:34efddfd06766d1153d10a70c23a98f6035e253a906db8ed04cb0249fc3b0fd2", size = 287868, upload-time = "2026-04-02T11:28:57.862Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/07/e217beea9a543c53484144164db337b33ec7f95912cc76f09f03fbc6ee7f/confluent_kafka-2.14.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:05bbf9745cadb1a6fd3b03508572d2cd5455d8d9960a437537ddac9d3f89ee49", size = 3212541, upload-time = "2026-04-02T11:28:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/cbb44df7afa3ac8746e0ebc37be5f457d0e91e32648c144226da26c5f682/confluent_kafka-2.14.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:32a72ff85d7b4428532aa477b8dfa4223a5c69f4e90fecaa64e1924cc99a06b6", size = 3653993, upload-time = "2026-04-02T11:28:31.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/49/49d9e62ff70a06e68c96dd65d8e621583e6b51682ccc08051ec585bfdf96/confluent_kafka-2.14.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:4fd75d53e0e36f7ff9c5454f7a3cf4a54790db3bfda169c3b582ddc97111f6f6", size = 3739535, upload-time = "2026-04-02T11:28:32.844Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6a/df467787418c24e063ed0c19e96aedf05c26eabc32d8adc75235d45d830b/confluent_kafka-2.14.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:eb17528ec7b177ec5e38214852f3dadb5d77172e0fb25c7c992c0cbc3dcfbaa2", size = 3995845, upload-time = "2026-04-02T11:28:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/c5ce2a48ece0ae2dd050ab28d4cd81b9efc610276a4e72f622582f5371d3/confluent_kafka-2.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:578afb532ded604cb98174a14a88847367191bcbe4f52a1661f5238dc5cf75dd", size = 4290326, upload-time = "2026-04-02T11:28:36.679Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.128.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "email-validator" },
+    { name = "fastapi-cli", extra = ["standard"] },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "pydantic-extra-types" },
+    { name = "pydantic-settings" },
+    { name = "python-multipart" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[[package]]
+name = "fastapi-cli"
+version = "0.0.24"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "rich-toolkit" },
+    { name = "typer" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/58/74797ae9e4610cfa0c6b34c8309096d3b20bb29be3b8b5fbf1004d10fa5f/fastapi_cli-0.0.24.tar.gz", hash = "sha256:1afc9c9e21d7ebc8a3ca5e31790cd8d837742be7e4f8b9236e99cb3451f0de00", size = 19043, upload-time = "2026-02-24T10:45:10.476Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/4b/68f9fe268e535d79c76910519530026a4f994ce07189ac0dded45c6af825/fastapi_cli-0.0.24-py3-none-any.whl", hash = "sha256:4a1f78ed798f106b4fee85ca93b85d8fe33c0a3570f775964d37edb80b8f0edc", size = 12304, upload-time = "2026-02-24T10:45:09.552Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "fastapi-cloud-cli" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[[package]]
+name = "fastapi-cloud-cli"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastar" },
+    { name = "httpx" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "rich-toolkit" },
+    { name = "rignore" },
+    { name = "sentry-sdk" },
+    { name = "typer" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/57/cee8e91b83f39e75ae5562a2237261442a8179dcb3b631c7398113157398/fastapi_cloud_cli-0.17.1.tar.gz", hash = "sha256:0baece208fa88063bec46dccb5fb512f3199162092165e57654b44e64adbc44d", size = 47409, upload-time = "2026-04-27T13:38:07.094Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/a0/e252b68cf155409afabea037ab2971f41509481838847f6503fe890884ea/fastapi_cloud_cli-0.17.1-py3-none-any.whl", hash = "sha256:325e0199bdac7cb86f5df4f4a1d2070054095588088ef7b923a60cec458dcd63", size = 34046, upload-time = "2026-04-27T13:38:08.319Z" },
+]
+
+[[package]]
+name = "fastar"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/0f/0aeb3fc50046617702acc0078b277b58367fd62eb727b9ec733ae0e8bbcc/fastar-0.11.0.tar.gz", hash = "sha256:aa7f100f7313c03fdb20f1385927ba95671071ba308ad0c1763fef295e1895ce", size = 70238, upload-time = "2026-04-13T17:11:17.143Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/cd/3644c48ecac456f928c12d47ec3bed36c36555b17c3859856f1ff860265d/fastar-0.11.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:71375bd6f03c2a43eb47bd949ea38ff45434917f9cdac79675c5b9f60de4fa73", size = 707860, upload-time = "2026-04-13T17:10:00.371Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/dee04476ae3626b2b040a60ad84628f77e1ffd8444232f2426b0ca1e0d7e/fastar-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:eddfd9cab16e19ae247fe44bf992cb403ccfe27d3931d6de29a4695d95ad386c", size = 628216, upload-time = "2026-04-13T17:09:45.355Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/5e/9395c7353d079cb4f5be0f7982ce0dc9f2e7dec5fd175eef466729d6023a/fastar-0.11.0-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:7c371f1d4386c699018bb64eb2fa785feacf32785559049d2bb72fe4af023f53", size = 864378, upload-time = "2026-04-13T17:09:14.611Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/1e4f67148223ff219612b6281a6000357abbcc2417964fa5c83f11d68fce/fastar-0.11.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cad7fa41e3e66554387481c1a09365e4638becd322904932674159d5f4046728", size = 760921, upload-time = "2026-04-13T17:07:59.138Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/82/09d11fb6d12f17993ffaf32ffd30c3c121a11e2966e84f19fb6f66430118/fastar-0.11.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cf36652fa71b83761717c9899b98732498f8a2cb6327ff16bbf07f6be85c3437", size = 757012, upload-time = "2026-04-13T17:08:14.186Z" },
+    { url = "https://files.pythonhosted.org/packages/52/1f/5aeeacc4cb65615e2c9292cd9c5b0cd6fb6d2e6ee472ca6adc6c1b1b22ef/fastar-0.11.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f68ff8c17833053da4841720e95edde80ce45bb994b6b7d51418dddaac70ee47", size = 924510, upload-time = "2026-04-13T17:08:28.741Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1a/1e5bdabbeaf2e856928956292609f2ff6a650f94480fb8afaca30229e483/fastar-0.11.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4563ed37a12ea1cdc398af8571258d24b988bf342b7b3bf5451bd5891243280c", size = 816602, upload-time = "2026-04-13T17:08:59.461Z" },
+    { url = "https://files.pythonhosted.org/packages/87/24/f960147910da3bed41a3adfcb026e17d5f50f4cf467a3324237a7088f61a/fastar-0.11.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cee63c9875cba3b70dc44338c560facc5d6e763047dcc4a30501f9a68cf5f890", size = 819452, upload-time = "2026-04-13T17:09:29.926Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f4/3e77d7901d5707fd7f8a352e153c8ae09ea974e6fabad0b7c4eb9944b8d4/fastar-0.11.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:bd76bfffae6d0a91f4ac4a612f721e7aec108db97dccdd120ae063cd66959f27", size = 885254, upload-time = "2026-04-13T17:08:44.285Z" },
+    { url = "https://files.pythonhosted.org/packages/47/01/1585edd5ec47782ae93cd94edf05828e0ab02ef00aec00aea4194a600464/fastar-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8f5b707501ec01c1bc0518f741f01d322e50c9adc19a451aa24f67a2316e9397", size = 971496, upload-time = "2026-04-13T17:10:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e9/6874c9d1236ded565a0bed54b320ac9f165f287b1d89490fb70f9f323c81/fastar-0.11.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:37c0b5a88a657839aad98b0a6c9e4ac4c2c15d6b49c44ee3935c6b08e9d3e479", size = 1034685, upload-time = "2026-04-13T17:10:34.063Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d8/4ab20613ce2983427aee958e39be878dba874aa227c530a845e32429c4f6/fastar-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:6c55f536c62a6efb180c1af0d5182948bff576bbfe6276e8e1359c9c7d2215d8", size = 1072675, upload-time = "2026-04-13T17:10:50.53Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ae/5ac3b7c20ce4b08f011dd2b979f96caabe64f9b10b157f211ea91bdfadca/fastar-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3082eeca59e189b9039335862f4c2780c0c8871d656bfdf559db4414a105b251", size = 1029330, upload-time = "2026-04-13T17:11:08.138Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e7/37cd6a1d4e288292170b64e19d79ecce2a7de8bb76790323399a2abc4619/fastar-0.11.0-cp314-cp314-win32.whl", hash = "sha256:b201a0a4e29f9fec2a177e13154b8725ec65ab9f83bd6415483efaa2aa18344b", size = 453940, upload-time = "2026-04-13T17:11:48.713Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1c/795c878b1ee29d79021cf8ed81f18f2b25ccde58453b0d34b9bdc7e025ea/fastar-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:868fddb26072a43e870a8819134b9f80ee602931be5a76e6fb873e04da343637", size = 486334, upload-time = "2026-04-13T17:11:34.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/a4/113f104301df8bddcc0b3775b611a30cb7610baa3add933c7ccac9386467/fastar-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:3db39c9cc42abb0c780a26b299f24dfbc8be455985e969e15336d70d7b2f833b", size = 461534, upload-time = "2026-04-13T17:11:24.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a6/5c5f2c2c8e0c63e56a5636ebc7721589c889e94c0092cec7eb28ae7207e6/fastar-0.11.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:49c3299dec5e125e7ebaa27545714da9c7391777366015427e0ae62d548b442b", size = 707156, upload-time = "2026-04-13T17:10:02.176Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f7/982c01b61f0fc135ad2b16d01e6d0ee53cf8791e68827f5f7c5a65b2e5b1/fastar-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3328ed1ed56d31f5198350b17dd60449b8d6b9d47abb4688bab6aef4450a165b", size = 627032, upload-time = "2026-04-13T17:09:46.978Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c3/38f1dac77ae0c71c37b176277c96d830796b8ce2fe69705f917829b53829/fastar-0.11.0-cp314-cp314t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:bd3eca3bbfec84a614bcb4143b4ad4f784d0895babc26cfc88436af88ca23c7a", size = 864403, upload-time = "2026-04-13T17:09:16.58Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f0/e69c363bdb3e5a5848e937b662b5469581ee6682c51bc1c0556494773929/fastar-0.11.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff86a967acb0d621dd24063dda090daa67bf4993b9570e97fe156de88a9006ca", size = 759480, upload-time = "2026-04-13T17:08:00.599Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/29/4d8737590c2a6357d614d7cc7288e8f68e7e449680b8922997cc4349e65e/fastar-0.11.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:86eaf7c0e985d93a7734168be2fb232b2a8cca53e41431c2782d7c12b12c03b1", size = 756219, upload-time = "2026-04-13T17:08:15.699Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ec/400de7b3b7d48801908f19cf5462177104395799472671b3e8152b2b04ca/fastar-0.11.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91f07b0b8eb67e2f177733a1f884edad7dfb9f8977ffef15927b20cb9604027d", size = 923669, upload-time = "2026-04-13T17:08:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/01/8926c53da923fed7ab4b96e7fbf7f73b663beb4f02095b654d6fab46f9ad/fastar-0.11.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f85c896885eb4abf1a635d54dea22cac6ae48d04fc2ea26ae652fcf1febe1220", size = 815729, upload-time = "2026-04-13T17:09:01.204Z" },
+    { url = "https://files.pythonhosted.org/packages/89/f0/5fef4c7946e352651b504b1a4235dac3505e7cfd24020788ab50552e84bf/fastar-0.11.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:075c07095c8de4b774ba8f28b9c0a02b1a2cd254da50cbe464dd3bb2432e9158", size = 819812, upload-time = "2026-04-13T17:09:31.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c8/0ebc3298b4a45e7bddc50b169ae6a6f5b80c939394d4befe6e60de535ee7/fastar-0.11.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:07f028933820c65750baf3383b807ecce1cd9385cf00ce192b79d263ad6b856c", size = 884074, upload-time = "2026-04-13T17:08:45.802Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/9f/7baa4cdff8d6fbca41fa5c764b48a941fed8a9ec6c4cc92de65895a28299/fastar-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:039f875efa0f01fa43c20bf4e2fc7305489c61d0ac76eda991acfba7820a0e63", size = 969450, upload-time = "2026-04-13T17:10:18.667Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/dc/1ebbfb58a47056ba866494f19efbcdd2ba2897096b94f36e796594b4d05b/fastar-0.11.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:fff12452a9a5c6814a012445f26365541cc3d99dcca61f09762e6a389f7a32ea", size = 1033775, upload-time = "2026-04-13T17:10:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/5f/ce4e3914066f08c99eb8c32952cc07c1a013e81b1db1b0f598130bf6b974/fastar-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2bf733e09f942b6fa876efe30a90508d1f4caef5630c00fb2a84fba355873712", size = 1072158, upload-time = "2026-04-13T17:10:52.497Z" },
+    { url = "https://files.pythonhosted.org/packages/03/2a/6bca72992c84151c387cc6558f3867f5ebe5fb3684ee6fa9b76280ba4b8e/fastar-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d1531fa848fdd3677d2dce0a4b436ea64d9ae38fb8babe2ddbc180dd153cb7a3", size = 1028577, upload-time = "2026-04-13T17:11:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/83/18/7a7c15657a3da5569b26fc51cde6a80f8d84cb54b3b1aea6d74a103db4ad/fastar-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:5744551bc67c6fc6581cbd0e34a0fd6e2cd0bd30b43e94b1c3119cf35064b162", size = 453601, upload-time = "2026-04-13T17:11:53.726Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d8/331b59a6de279f3ad75c10c02c40a12f21d64a437d9c3d6f1af2dcbd7a76/fastar-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f4ce44e3b56c47cf38244b98d29f269b259740a580c47a2552efa5b96a5458fb", size = 486436, upload-time = "2026-04-13T17:11:40.089Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/fd/5390ec4f49100f3ecb9968a392f9e6d039f1e3fe0ecd28443716ff01e589/fastar-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:76c1359314355eafbc6989f20fb1ad565a3d10200117923b9da765a17e2f6f11", size = 461049, upload-time = "2026-04-13T17:11:25.918Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hiredis"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/d6/9bef6dc3052c168c93fbf7e6c0f2b12c45f0f741a2d30fd919096774343a/hiredis-3.3.1.tar.gz", hash = "sha256:da6f0302360e99d32bc2869772692797ebadd536e1b826d0103c72ba49d38698", size = 89101, upload-time = "2026-03-16T15:21:08.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/72/0450d6b449da58120c5497346eb707738f8f67b9e60c28a8ef90133fc81f/hiredis-3.3.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:439f9a5cc8f9519ce208a24cdebfa0440fef26aa682a40ba2c92acb10a53f5e0", size = 82112, upload-time = "2026-03-16T15:20:02.865Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c0/0be33a29bcd463e6cbb0282515dd4d0cdfe33c30c7afc6d4d8c460e23266/hiredis-3.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3724f0e58c6ff76fd683429945491de71324ab1bc0ad943a8d68cb0932d24075", size = 46238, upload-time = "2026-03-16T15:20:03.896Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/f999854bfaf3bcbee0f797f24706c182ecfaca825f6a582f6281a6aa97e0/hiredis-3.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29fe35e3c6fe03204e75c86514f452591957a1e06b05d86e10d795455b71c355", size = 41891, upload-time = "2026-03-16T15:20:04.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c8/cd9ab90fec3a301d864d8ab6167aea387add8e2287969d89cbcd45d6b0e0/hiredis-3.3.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d42f3a13290f89191568fc113d95a3d2c8759cdd8c3672f021d8b7436f909e75", size = 170485, upload-time = "2026-03-16T15:20:06.284Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9a/1ddf9ea236a292963146cbaf6722abeb9d503ca47d821267bb8b3b81c4f7/hiredis-3.3.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2afc675b831f7552da41116fffffca4340f387dc03f56d6ec0c7895ab0b59a10", size = 182030, upload-time = "2026-03-16T15:20:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/b8/e070a1dbf8a1bbb8814baa0b00836fbe3f10c7af8e11f942cc739c64e062/hiredis-3.3.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4106201cd052d9eabe3cb7b5a24b0fe37307792bda4fcb3cf6ddd72f697828e8", size = 180543, upload-time = "2026-03-16T15:20:09.096Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bb/b5f4f98e44626e2446cd8a52ce6cb1fc1c99786b6e2db3bf09cea97b90cd/hiredis-3.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8887bf0f31e4b550bd988c8863b527b6587d200653e9375cd91eea2b944b7424", size = 172356, upload-time = "2026-03-16T15:20:10.245Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/93/73a77b54ba94e82f76d02563c588d8a062513062675f483a033a43015f2c/hiredis-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ac7697365dbe45109273b34227fee6826b276ead9a4a007e0877e1d3f0fcf21", size = 166433, upload-time = "2026-03-16T15:20:11.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c2/1b2dcbe5dc53a46a8cb05bed67d190a7e30bad2ad1f727ebe154dfeededd/hiredis-3.3.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2b6da6e07359107c653a809b3cff2d9ccaeedbafe33c6f16434aef6f53ce4a2b", size = 177220, upload-time = "2026-03-16T15:20:12.991Z" },
+    { url = "https://files.pythonhosted.org/packages/02/09/f4314cf096552568b5ea785ceb60c424771f4d35a76c410ad39d258f74bc/hiredis-3.3.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:ce334915f5d31048f76a42c607bf26687cf045eb1bc852b7340f09729c6a64fc", size = 170475, upload-time = "2026-03-16T15:20:14.519Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2e/3f56e438efc8fc27ed4a3dbad58c0280061466473ec35d8f86c90c841a84/hiredis-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ee11fd431f83d8a5b29d370b9d79a814d3218d30113bdcd44657e9bdf715fc92", size = 167913, upload-time = "2026-03-16T15:20:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/56/34/053e5ee91d6dc478faac661996d1fd4886c5acb7a1b5ac30e7d3c794bb51/hiredis-3.3.1-cp314-cp314-win32.whl", hash = "sha256:e0356561b4a97c83b9ee3de657a41b8d1a1781226853adaf47b550bb988fda6f", size = 21167, upload-time = "2026-03-16T15:20:17.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/33/06776c641d17881a9031e337e81b3b934c38c2adbb83c85062d6b5f83b72/hiredis-3.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:80aba5f85d6227faee628ae28d1c3b69c661806a0636548ac56c68782606454f", size = 23000, upload-time = "2026-03-16T15:20:17.966Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5a/94f9a505b2ff5376d4a05fb279b69d89bafa7219dd33f6944026e3e56f80/hiredis-3.3.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:907f7b5501a534030738f0f27459a612d2266fd0507b007bb8f3e6de08167920", size = 83039, upload-time = "2026-03-16T15:20:19.316Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ae/d3752a8f03a1fca43d402389d2a2d234d3db54c4d1f07f26c1041ca3c5de/hiredis-3.3.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:de94b409f49eb6a588ebdd5872e826caec417cd77c17af0fb94f2128427f1a2a", size = 46703, upload-time = "2026-03-16T15:20:20.401Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/76/e32c868a2fa23cd82bacaffd38649d938173244a0e717ec1c0c76874dbdd/hiredis-3.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79cd03e7ff550c17758a7520bf437c156d3d4c8bb74214deeafa69cda49c85a4", size = 42379, upload-time = "2026-03-16T15:20:21.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f6/d687d36a74ce6cf448826cf2e8edfc1eb37cc965308f74eb696aa97c69df/hiredis-3.3.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ffa7ba2e2da1f806f3181b9730b3e87ba9dbfec884806725d4584055ba3faa6", size = 180311, upload-time = "2026-03-16T15:20:23.037Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ac/f520dc0066a62a15aa920c7dd0a2028c213f4862d5f901409ae92ee5d785/hiredis-3.3.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ee37fe8cf081b72dea72f96a0ee604f492ec02252eb77dc26ff6eec3f997b580", size = 190488, upload-time = "2026-03-16T15:20:24.357Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f5/ae10fff82d0f291e90c41bf10a5d6543a96aae00cccede01bf2b6f7e178d/hiredis-3.3.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9bfdeff778d3f7ff449ca5922ab773899e7d31e26a576028b06a5e9cf0ed8c34", size = 189210, upload-time = "2026-03-16T15:20:25.51Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8f/5be4344e542aa8d349a03d05486c59d9ca26f69c749d11e114bf34b84d50/hiredis-3.3.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:027ce4fabfeff5af5b9869d5524770877f9061d118bc36b85703ae3faf5aad8e", size = 180971, upload-time = "2026-03-16T15:20:26.631Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a2/29e230226ec2a31f13f8a832fbafe366e263f3b090553ebe49bb4581a7bd/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:dcea8c3f53674ae68e44b12e853b844a1d315250ca6677b11ec0c06aff85e86c", size = 175314, upload-time = "2026-03-16T15:20:27.848Z" },
+    { url = "https://files.pythonhosted.org/packages/89/2e/bf241707ad86b9f3ebfbc7ab89e19d5ec243ff92ca77644a383622e8740b/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0b5ff2f643f4b452b0597b7fe6aa35d398cb31d8806801acfafb1558610ea2aa", size = 185652, upload-time = "2026-03-16T15:20:29.364Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c1/b39170d8bcccd01febd45af4ac6b43ff38e134a868e2ec167a82a036fb35/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:3586c8a5f56d34b9dddaaa9e76905f31933cac267251006adf86ec0eef7d0400", size = 179033, upload-time = "2026-03-16T15:20:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/3a/4fe39a169115434f911abff08ff485b9b6201c168500e112b3f6a8110c0a/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a110d19881ca78a88583d3b07231e7c6864864f5f1f3491b638863ea45fa8708", size = 176126, upload-time = "2026-03-16T15:20:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/44/99/c1d0b0bc4f9e9150e24beb0dca2e186e32d5e749d0022e0d26453749ed51/hiredis-3.3.1-cp314-cp314t-win32.whl", hash = "sha256:98fd5b39410e9d69e10e90d0330e35650becaa5dd2548f509b9598f1f3c6124d", size = 22028, upload-time = "2026-03-16T15:20:33.33Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d6/191e6741addc97bcf5e755661f8c82f0fd0aa35f07ece56e858da689b57e/hiredis-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ab1f646ff531d70bfd25f01e60708dfa3d105eb458b7dedd9fe9a443039fd809", size = 23811, upload-time = "2026-03-16T15:20:34.292Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "lz4"
+version = "4.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/51/f1b86d93029f418033dddf9b9f79c8d2641e7454080478ee2aab5123173e/lz4-4.4.5.tar.gz", hash = "sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0", size = 172886, upload-time = "2025-11-03T13:02:36.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/9c/70bdbdb9f54053a308b200b4678afd13efd0eafb6ddcbb7f00077213c2e5/lz4-4.4.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c216b6d5275fc060c6280936bb3bb0e0be6126afb08abccde27eed23dead135f", size = 207586, upload-time = "2025-11-03T13:02:18.263Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/cb/bfead8f437741ce51e14b3c7d404e3a1f6b409c440bad9b8f3945d4c40a7/lz4-4.4.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c8e71b14938082ebaf78144f3b3917ac715f72d14c076f384a4c062df96f9df6", size = 207161, upload-time = "2025-11-03T13:02:19.286Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/18/b192b2ce465dfbeabc4fc957ece7a1d34aded0d95a588862f1c8a86ac448/lz4-4.4.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9b5e6abca8df9f9bdc5c3085f33ff32cdc86ed04c65e0355506d46a5ac19b6e9", size = 1292415, upload-time = "2025-11-03T13:02:20.829Z" },
+    { url = "https://files.pythonhosted.org/packages/67/79/a4e91872ab60f5e89bfad3e996ea7dc74a30f27253faf95865771225ccba/lz4-4.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b84a42da86e8ad8537aabef062e7f661f4a877d1c74d65606c49d835d36d668", size = 1279920, upload-time = "2025-11-03T13:02:22.013Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/01/d52c7b11eaa286d49dae619c0eec4aabc0bf3cda7a7467eb77c62c4471f3/lz4-4.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bba042ec5a61fa77c7e380351a61cb768277801240249841defd2ff0a10742f", size = 1368661, upload-time = "2025-11-03T13:02:23.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/137ddeea14c2cb86864838277b2607d09f8253f152156a07f84e11768a28/lz4-4.4.5-cp314-cp314-win32.whl", hash = "sha256:bd85d118316b53ed73956435bee1997bd06cc66dd2fa74073e3b1322bd520a67", size = 90139, upload-time = "2025-11-03T13:02:24.301Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2c/8332080fd293f8337779a440b3a143f85e374311705d243439a3349b81ad/lz4-4.4.5-cp314-cp314-win_amd64.whl", hash = "sha256:92159782a4502858a21e0079d77cdcaade23e8a5d252ddf46b0652604300d7be", size = 101497, upload-time = "2025-11-03T13:02:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/28/2635a8141c9a4f4bc23f5135a92bbcf48d928d8ca094088c962df1879d64/lz4-4.4.5-cp314-cp314-win_arm64.whl", hash = "sha256:d994b87abaa7a88ceb7a37c90f547b8284ff9da694e6afcfaa8568d739faf3f7", size = 93812, upload-time = "2025-11-03T13:02:26.133Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "metranova"
+version = "0.1.0"
+source = { git = "https://github.com/MetrANOVA/api.git?subdirectory=packages%2Fmetranova&branch=main#e7e530b0435b3a054d9c0fe72f9ad14d51c712de" }
+dependencies = [
+    { name = "clickhouse-connect" },
+    { name = "fastapi", extra = ["standard"] },
+    { name = "httpx" },
+    { name = "pydantic-settings" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/4d/8df5f83256a809c22c4d6792ce8d43bb503be0fb7a8e4da9025754b09658/orjson-3.11.3.tar.gz", hash = "sha256:1c0603b1d2ffcd43a411d64797a19556ef76958aef1c182f22dc30860152a98a", size = 5482394, upload-time = "2025-08-26T17:46:43.171Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/77/d3b1fef1fc6aaeed4cbf3be2b480114035f4df8fa1a99d2dac1d40d6e924/orjson-3.11.3-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:cf4b81227ec86935568c7edd78352a92e97af8da7bd70bdfdaa0d2e0011a1ab4", size = 238115, upload-time = "2025-08-26T17:46:01.669Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6d/468d21d49bb12f900052edcfbf52c292022d0a323d7828dc6376e6319703/orjson-3.11.3-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:bc8bc85b81b6ac9fc4dae393a8c159b817f4c2c9dee5d12b773bddb3b95fc07e", size = 127493, upload-time = "2025-08-26T17:46:03.466Z" },
+    { url = "https://files.pythonhosted.org/packages/67/46/1e2588700d354aacdf9e12cc2d98131fb8ac6f31ca65997bef3863edb8ff/orjson-3.11.3-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:88dcfc514cfd1b0de038443c7b3e6a9797ffb1b3674ef1fd14f701a13397f82d", size = 122998, upload-time = "2025-08-26T17:46:04.803Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/94/11137c9b6adb3779f1b34fd98be51608a14b430dbc02c6d41134fbba484c/orjson-3.11.3-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:d61cd543d69715d5fc0a690c7c6f8dcc307bc23abef9738957981885f5f38229", size = 132915, upload-time = "2025-08-26T17:46:06.237Z" },
+    { url = "https://files.pythonhosted.org/packages/10/61/dccedcf9e9bcaac09fdabe9eaee0311ca92115699500efbd31950d878833/orjson-3.11.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2b7b153ed90ababadbef5c3eb39549f9476890d339cf47af563aea7e07db2451", size = 130907, upload-time = "2025-08-26T17:46:07.581Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/fd/0e935539aa7b08b3ca0f817d73034f7eb506792aae5ecc3b7c6e679cdf5f/orjson-3.11.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:7909ae2460f5f494fecbcd10613beafe40381fd0316e35d6acb5f3a05bfda167", size = 403852, upload-time = "2025-08-26T17:46:08.982Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/2b/50ae1a5505cd1043379132fdb2adb8a05f37b3e1ebffe94a5073321966fd/orjson-3.11.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:2030c01cbf77bc67bee7eef1e7e31ecf28649353987775e3583062c752da0077", size = 146309, upload-time = "2025-08-26T17:46:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/1d/a473c158e380ef6f32753b5f39a69028b25ec5be331c2049a2201bde2e19/orjson-3.11.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a0169ebd1cbd94b26c7a7ad282cf5c2744fce054133f959e02eb5265deae1872", size = 135424, upload-time = "2025-08-26T17:46:12.386Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/17d9d2b60592890ff7382e591aa1d9afb202a266b180c3d4049b1ec70e4a/orjson-3.11.3-cp314-cp314-win32.whl", hash = "sha256:0c6d7328c200c349e3a4c6d8c83e0a5ad029bdc2d417f234152bf34842d0fc8d", size = 136266, upload-time = "2025-08-26T17:46:13.853Z" },
+    { url = "https://files.pythonhosted.org/packages/15/58/358f6846410a6b4958b74734727e582ed971e13d335d6c7ce3e47730493e/orjson-3.11.3-cp314-cp314-win_amd64.whl", hash = "sha256:317bbe2c069bbc757b1a2e4105b64aacd3bc78279b66a6b9e51e846e4809f804", size = 131351, upload-time = "2025-08-26T17:46:15.27Z" },
+    { url = "https://files.pythonhosted.org/packages/28/01/d6b274a0635be0468d4dbd9cafe80c47105937a0d42434e805e67cd2ed8b/orjson-3.11.3-cp314-cp314-win_arm64.whl", hash = "sha256:e8f6a7a27d7b7bec81bd5924163e9af03d49bbb63013f107b48eb5d16db711bc", size = 125985, upload-time = "2025-08-26T17:46:16.67Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pipeline"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "cachetools" },
+    { name = "clickhouse-connect" },
+    { name = "confluent-kafka" },
+    { name = "metranova" },
+    { name = "orjson" },
+    { name = "pycountry" },
+    { name = "pycountry-convert" },
+    { name = "pytricia" },
+    { name = "pyyaml" },
+    { name = "redis", extra = ["hiredis"] },
+    { name = "requests" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cachetools", specifier = "==6.2.1" },
+    { name = "clickhouse-connect", specifier = "==0.15.0" },
+    { name = "confluent-kafka", specifier = "==2.14.0" },
+    { name = "metranova", git = "https://github.com/MetrANOVA/api.git?subdirectory=packages%2Fmetranova&branch=main" },
+    { name = "orjson", specifier = "==3.11.3" },
+    { name = "pycountry", specifier = "==24.6.1" },
+    { name = "pycountry-convert", specifier = "==0.7.2" },
+    { name = "pytricia", specifier = "==1.3.0" },
+    { name = "pyyaml", specifier = "==6.0.3" },
+    { name = "redis", extras = ["hiredis"], specifier = "==6.4.0" },
+    { name = "requests", specifier = "==2.32.5" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pprintpp"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/1a/7737e7a0774da3c3824d654993cf57adc915cb04660212f03406334d8c0b/pprintpp-0.4.0.tar.gz", hash = "sha256:ea826108e2c7f49dc6d66c752973c3fc9749142a798d6b254e1e301cfdbc6403", size = 17995, upload-time = "2018-07-01T01:42:34.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/d1/e4ed95fdd3ef13b78630280d9e9e240aeb65cc7c544ec57106149c3942fb/pprintpp-0.4.0-py2.py3-none-any.whl", hash = "sha256:b6b4dcdd0c0c0d75e4d7b2f21a9e933e5b2ce62b26e1a54537f9651ae5a5c01d", size = 16952, upload-time = "2018-07-01T01:42:36.496Z" },
+]
+
+[[package]]
+name = "pycountry"
+version = "24.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/57/c389fa68c50590881a75b7883eeb3dc15e9e73a0fdc001cdd45c13290c92/pycountry-24.6.1.tar.gz", hash = "sha256:b61b3faccea67f87d10c1f2b0fc0be714409e8fcdcc1315613174f6466c10221", size = 6043910, upload-time = "2024-06-01T04:12:15.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/ec/1fb891d8a2660716aadb2143235481d15ed1cbfe3ad669194690b0604492/pycountry-24.6.1-py3-none-any.whl", hash = "sha256:f1a4fb391cd7214f8eefd39556d740adcc233c778a27f8942c8dca351d6ce06f", size = 6335189, upload-time = "2024-06-01T04:11:49.711Z" },
+]
+
+[[package]]
+name = "pycountry-convert"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pprintpp" },
+    { name = "pycountry" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "repoze-lru" },
+    { name = "wheel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/85/a5bcf01c5e8de1b611990c723e2b88bdbfb93375e18d1539f6fa8f0f9952/pycountry-convert-0.7.2.tar.gz", hash = "sha256:095d310f746bf2a5ef713b3a82eea28a27262286223765b1e7be8a5c4fa7e9b9", size = 12376, upload-time = "2018-02-18T17:36:06.648Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/e7/26c14899a43c34e04a58e3772007afe79dbd64fac15d2fbaeedff24082f2/pycountry_convert-0.7.2-py3-none-any.whl", hash = "sha256:5e33883a88b3cb752d332ca2358ac6c4de4defc86a2b93b713b36338e914952e", size = 13836, upload-time = "2018-02-18T17:36:09.704Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/db/a7bcb4940183fda36022cd18ba8dd12f2dff40740ec7b58ce7457befa416/pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b", size = 2097614, upload-time = "2026-04-20T14:44:38.374Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/e4066358a22e3e99519db370494c7528f5a2aa1367370e80e27e20283543/pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018", size = 1951896, upload-time = "2026-04-20T14:40:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/87/92/37cf4049d1636996e4b888c05a501f40a43ff218983a551d57f9d5e14f0d/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34", size = 1979314, upload-time = "2026-04-20T14:41:49.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/9ff4d676dfbdfb2d591cf43f3d90ded01e15b1404fd101180ed2d62a2fd3/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7", size = 2056133, upload-time = "2026-04-20T14:42:23.574Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f0/405b442a4d7ba855b06eec8b2bf9c617d43b8432d099dfdc7bf999293495/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2", size = 2228726, upload-time = "2026-04-20T14:44:22.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f8/65cd92dd5a0bd89ba277a98ecbfaf6fc36bbd3300973c7a4b826d6ab1391/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba", size = 2301214, upload-time = "2026-04-20T14:44:48.792Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/86/ef96a4c6e79e7a2d0410826a68fbc0eccc0fd44aa733be199d5fcac3bb87/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f", size = 2099927, upload-time = "2026-04-20T14:41:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/53/269caf30e0096e0a8a8f929d1982a27b3879872cca2d917d17c2f9fdf4fe/pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22", size = 2128789, upload-time = "2026-04-20T14:41:15.868Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b0/1a6d9b6a587e118482910c244a1c5acf4d192604174132efd12bf0ac486f/pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f", size = 2173815, upload-time = "2026-04-20T14:44:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/87/56/e7e00d4041a7e62b5a40815590114db3b535bf3ca0bf4dca9f16cef25246/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127", size = 2181608, upload-time = "2026-04-20T14:41:28.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/22/4bd23c3d41f7c185d60808a1de83c76cf5aeabf792f6c636a55c3b1ec7f9/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c", size = 2326968, upload-time = "2026-04-20T14:42:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ac/66cd45129e3915e5ade3b292cb3bc7fd537f58f8f8dbdaba6170f7cabb74/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1", size = 2369842, upload-time = "2026-04-20T14:41:35.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/dd4248abb84113615473aa20d5545b7c4cd73c8644003b5259686f93996c/pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505", size = 1959661, upload-time = "2026-04-20T14:41:00.042Z" },
+    { url = "https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e", size = 2071686, upload-time = "2026-04-20T14:43:16.471Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/db/1cf77e5247047dfee34bc01fa9bca134854f528c8eb053e144298893d370/pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df", size = 2026907, upload-time = "2026-04-20T14:43:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c0/b3df9f6a543276eadba0a48487b082ca1f201745329d97dbfa287034a230/pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf", size = 2095047, upload-time = "2026-04-20T14:42:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/57/886a938073b97556c168fd99e1a7305bb363cd30a6d2c76086bf0587b32a/pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee", size = 1934329, upload-time = "2026-04-20T14:43:49.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7c/b42eaa5c34b13b07ecb51da21761297a9b8eb43044c864a035999998f328/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a", size = 1974847, upload-time = "2026-04-20T14:42:10.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9b/92b42db6543e7de4f99ae977101a2967b63122d4b6cf7773812da2d7d5b5/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c", size = 2041742, upload-time = "2026-04-20T14:40:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/19/46fbe1efabb5aa2834b43b9454e70f9a83ad9c338c1291e48bdc4fecf167/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1", size = 2236235, upload-time = "2026-04-20T14:41:27.307Z" },
+    { url = "https://files.pythonhosted.org/packages/77/da/b3f95bc009ad60ec53120f5d16c6faa8cabdbe8a20d83849a1f2b8728148/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64", size = 2282633, upload-time = "2026-04-20T14:44:33.271Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/401336117722e28f32fb8220df676769d28ebdf08f2f4469646d404c43a3/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb", size = 2109679, upload-time = "2026-04-20T14:44:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/53/b289f9bc8756a32fe718c46f55afaeaf8d489ee18d1a1e7be1db73f42cc4/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6", size = 2108342, upload-time = "2026-04-20T14:42:50.144Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5b/8292fc7c1f9111f1b2b7c1b0dcf1179edcd014fc3ea4517499f50b829d71/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c", size = 2157208, upload-time = "2026-04-20T14:42:08.133Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9e/f80044e9ec07580f057a89fc131f78dda7a58751ddf52bbe05eaf31db50f/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47", size = 2167237, upload-time = "2026-04-20T14:42:25.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/6781a1b037f3b96be9227edbd1101f6d3946746056231bf4ac48cdff1a8d/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab", size = 2312540, upload-time = "2026-04-20T14:40:40.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/db/19c0839feeb728e7df03255581f198dfdf1c2aeb1e174a8420b63c5252e5/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba", size = 2369556, upload-time = "2026-04-20T14:41:09.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756, upload-time = "2026-04-20T14:41:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305, upload-time = "2026-04-20T14:43:18.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310, upload-time = "2026-04-20T14:41:01.778Z" },
+]
+
+[[package]]
+name = "pydantic-extra-types"
+version = "2.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl", hash = "sha256:1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1", size = 79526, upload-time = "2026-03-16T08:08:02.533Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
+]
+
+[[package]]
+name = "pytricia"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/c6/e077cffbf4a2f364657b757fccd8f4694bffc6350fc30a563246bc5fbd9d/pytricia-1.3.0.tar.gz", hash = "sha256:1c3a3d6909e10d4c9c2f0fe4542a2481e109d29aab99cc027ca7fe93f8c8853f", size = 34118, upload-time = "2025-09-15T14:46:33.943Z" }
+
+[[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "6.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/d6/e8b92798a5bd67d659d51a18170e91c16ac3b59738d91894651ee255ed49/redis-6.4.0.tar.gz", hash = "sha256:b01bc7282b8444e28ec36b261df5375183bb47a07eb9c603f284e89cbc5ef010", size = 4647399, upload-time = "2025-08-07T08:10:11.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/02/89e2ed7e85db6c93dfa9e8f691c5087df4e3551ab39081a4d7c6d1f90e05/redis-6.4.0-py3-none-any.whl", hash = "sha256:f0544fa9604264e9464cdf4814e7d4830f74b165d52f2a330a760a88dd248b7f", size = 279847, upload-time = "2025-08-07T08:10:09.84Z" },
+]
+
+[package.optional-dependencies]
+hiredis = [
+    { name = "hiredis" },
+]
+
+[[package]]
+name = "repoze-lru"
+version = "0.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/bc/595a77c4b5e204847fdf19268314ef59c85193a9dc9f83630fc459c0fee5/repoze.lru-0.7.tar.gz", hash = "sha256:0429a75e19380e4ed50c0694e26ac8819b4ea7851ee1fc7583c8572db80aff77", size = 19591, upload-time = "2017-09-07T05:01:00.949Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/30/6cc0c95f0b59ad4b3b9163bff7cdcf793cc96fac64cf398ff26271f5cf5e/repoze.lru-0.7-py3-none-any.whl", hash = "sha256:f77bf0e1096ea445beadd35f3479c5cff2aa1efe604a133e67150bc8630a62ea", size = 10985, upload-time = "2017-09-07T05:01:00.007Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-toolkit"
+version = "0.19.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/ba/dae9e3096651042754da419a4042bc1c75e07d615f9b15066d738838e4df/rich_toolkit-0.19.7.tar.gz", hash = "sha256:133c0915872da91d4c25d85342d5ec1dfacc69b63448af1a08a0d4b4f23ef46e", size = 195877, upload-time = "2026-02-24T16:06:20.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/3c/c923619f6d2f5fafcc96fec0aaf9550a46cd5b6481f06e0c6b66a2a4fed0/rich_toolkit-0.19.7-py3-none-any.whl", hash = "sha256:0288e9203728c47c5a4eb60fd2f0692d9df7455a65901ab6f898437a2ba5989d", size = 32963, upload-time = "2026-02-24T16:06:22.066Z" },
+]
+
+[[package]]
+name = "rignore"
+version = "0.7.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/f5/8bed2310abe4ae04b67a38374a4d311dd85220f5d8da56f47ae9361be0b0/rignore-0.7.6.tar.gz", hash = "sha256:00d3546cd793c30cb17921ce674d2c8f3a4b00501cb0e3dd0e82217dbeba2671", size = 57140, upload-time = "2025-11-05T21:41:21.968Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/b9/1f5bd82b87e5550cd843ceb3768b4a8ef274eb63f29333cf2f29644b3d75/rignore-0.7.6-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:8e41be9fa8f2f47239ded8920cc283699a052ac4c371f77f5ac017ebeed75732", size = 882632, upload-time = "2025-11-05T20:42:44.063Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/6b/07714a3efe4a8048864e8a5b7db311ba51b921e15268b17defaebf56d3db/rignore-0.7.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6dc1e171e52cefa6c20e60c05394a71165663b48bca6c7666dee4f778f2a7d90", size = 820760, upload-time = "2025-11-05T20:42:27.885Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0f/348c829ea2d8d596e856371b14b9092f8a5dfbb62674ec9b3f67e4939a9d/rignore-0.7.6-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ce2268837c3600f82ab8db58f5834009dc638ee17103582960da668963bebc5", size = 899044, upload-time = "2025-11-05T20:40:55.336Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/30/2e1841a19b4dd23878d73edd5d82e998a83d5ed9570a89675f140ca8b2ad/rignore-0.7.6-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:690a3e1b54bfe77e89c4bacb13f046e642f8baadafc61d68f5a726f324a76ab6", size = 874144, upload-time = "2025-11-05T20:41:10.195Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/bf/0ce9beb2e5f64c30e3580bef09f5829236889f01511a125f98b83169b993/rignore-0.7.6-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:09d12ac7a0b6210c07bcd145007117ebd8abe99c8eeb383e9e4673910c2754b2", size = 1168062, upload-time = "2025-11-05T20:41:26.511Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/8b/571c178414eb4014969865317da8a02ce4cf5241a41676ef91a59aab24de/rignore-0.7.6-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2a2b2b74a8c60203b08452479b90e5ce3dbe96a916214bc9eb2e5af0b6a9beb0", size = 942542, upload-time = "2025-11-05T20:41:41.838Z" },
+    { url = "https://files.pythonhosted.org/packages/19/62/7a3cf601d5a45137a7e2b89d10c05b5b86499190c4b7ca5c3c47d79ee519/rignore-0.7.6-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8fc5a531ef02131e44359419a366bfac57f773ea58f5278c2cdd915f7d10ea94", size = 958739, upload-time = "2025-11-05T20:42:12.463Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/1f/4261f6a0d7caf2058a5cde2f5045f565ab91aa7badc972b57d19ce58b14e/rignore-0.7.6-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b7a1f77d9c4cd7e76229e252614d963442686bfe12c787a49f4fe481df49e7a9", size = 984138, upload-time = "2025-11-05T20:41:56.775Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/bf/628dfe19c75e8ce1f45f7c248f5148b17dfa89a817f8e3552ab74c3ae812/rignore-0.7.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ead81f728682ba72b5b1c3d5846b011d3e0174da978de87c61645f2ed36659a7", size = 1079299, upload-time = "2025-11-05T21:40:16.639Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a5/be29c50f5c0c25c637ed32db8758fdf5b901a99e08b608971cda8afb293b/rignore-0.7.6-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:12ffd50f520c22ffdabed8cd8bfb567d9ac165b2b854d3e679f4bcaef11a9441", size = 1139618, upload-time = "2025-11-05T21:40:34.507Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/40/3c46cd7ce4fa05c20b525fd60f599165e820af66e66f2c371cd50644558f/rignore-0.7.6-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:e5a16890fbe3c894f8ca34b0fcacc2c200398d4d46ae654e03bc9b3dbf2a0a72", size = 1117626, upload-time = "2025-11-05T21:40:51.494Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/b9/aea926f263b8a29a23c75c2e0d8447965eb1879d3feb53cfcf84db67ed58/rignore-0.7.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3abab3bf99e8a77488ef6c7c9a799fac22224c28fe9f25cc21aa7cc2b72bfc0b", size = 1128144, upload-time = "2025-11-05T21:41:09.169Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f6/0d6242f8d0df7f2ecbe91679fefc1f75e7cd2072cb4f497abaab3f0f8523/rignore-0.7.6-cp314-cp314-win32.whl", hash = "sha256:eeef421c1782953c4375aa32f06ecae470c1285c6381eee2a30d2e02a5633001", size = 646385, upload-time = "2025-11-05T21:41:55.105Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/38/c0dcd7b10064f084343d6af26fe9414e46e9619c5f3224b5272e8e5d9956/rignore-0.7.6-cp314-cp314-win_amd64.whl", hash = "sha256:6aeed503b3b3d5af939b21d72a82521701a4bd3b89cd761da1e7dc78621af304", size = 725738, upload-time = "2025-11-05T21:41:39.736Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/7a/290f868296c1ece914d565757ab363b04730a728b544beb567ceb3b2d96f/rignore-0.7.6-cp314-cp314-win_arm64.whl", hash = "sha256:104f215b60b3c984c386c3e747d6ab4376d5656478694e22c7bd2f788ddd8304", size = 656008, upload-time = "2025-11-05T21:41:29.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d2/3c74e3cd81fe8ea08a8dcd2d755c09ac2e8ad8fe409508904557b58383d3/rignore-0.7.6-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:bb24a5b947656dd94cb9e41c4bc8b23cec0c435b58be0d74a874f63c259549e8", size = 882835, upload-time = "2025-11-05T20:42:45.443Z" },
+    { url = "https://files.pythonhosted.org/packages/77/61/a772a34b6b63154877433ac2d048364815b24c2dd308f76b212c408101a2/rignore-0.7.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5b1e33c9501cefe24b70a1eafd9821acfd0ebf0b35c3a379430a14df089993e3", size = 820301, upload-time = "2025-11-05T20:42:29.226Z" },
+    { url = "https://files.pythonhosted.org/packages/71/30/054880b09c0b1b61d17eeb15279d8bf729c0ba52b36c3ada52fb827cbb3c/rignore-0.7.6-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bec3994665a44454df86deb762061e05cd4b61e3772f5b07d1882a8a0d2748d5", size = 897611, upload-time = "2025-11-05T20:40:56.475Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/40/b2d1c169f833d69931bf232600eaa3c7998ba4f9a402e43a822dad2ea9f2/rignore-0.7.6-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:26cba2edfe3cff1dfa72bddf65d316ddebf182f011f2f61538705d6dbaf54986", size = 873875, upload-time = "2025-11-05T20:41:11.561Z" },
+    { url = "https://files.pythonhosted.org/packages/55/59/ca5ae93d83a1a60e44b21d87deb48b177a8db1b85e82fc8a9abb24a8986d/rignore-0.7.6-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ffa86694fec604c613696cb91e43892aa22e1fec5f9870e48f111c603e5ec4e9", size = 1167245, upload-time = "2025-11-05T20:41:28.29Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/52/cf3dce392ba2af806cba265aad6bcd9c48bb2a6cb5eee448d3319f6e505b/rignore-0.7.6-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48efe2ed95aa8104145004afb15cdfa02bea5cdde8b0344afeb0434f0d989aa2", size = 941750, upload-time = "2025-11-05T20:41:43.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/be/3f344c6218d779395e785091d05396dfd8b625f6aafbe502746fcd880af2/rignore-0.7.6-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dcae43eb44b7f2457fef7cc87f103f9a0013017a6f4e62182c565e924948f21", size = 958896, upload-time = "2025-11-05T20:42:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/34/d3fa71938aed7d00dcad87f0f9bcb02ad66c85d6ffc83ba31078ce53646a/rignore-0.7.6-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2cd649a7091c0dad2f11ef65630d30c698d505cbe8660dd395268e7c099cc99f", size = 983992, upload-time = "2025-11-05T20:41:58.022Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a4/52a697158e9920705bdbd0748d59fa63e0f3233fb92e9df9a71afbead6ca/rignore-0.7.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:42de84b0289d478d30ceb7ae59023f7b0527786a9a5b490830e080f0e4ea5aeb", size = 1078181, upload-time = "2025-11-05T21:40:18.151Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/65/aa76dbcdabf3787a6f0fd61b5cc8ed1e88580590556d6c0207960d2384bb/rignore-0.7.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:875a617e57b53b4acbc5a91de418233849711c02e29cc1f4f9febb2f928af013", size = 1139232, upload-time = "2025-11-05T21:40:35.966Z" },
+    { url = "https://files.pythonhosted.org/packages/08/44/31b31a49b3233c6842acc1c0731aa1e7fb322a7170612acf30327f700b44/rignore-0.7.6-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8703998902771e96e49968105207719f22926e4431b108450f3f430b4e268b7c", size = 1117349, upload-time = "2025-11-05T21:40:53.013Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ae/1b199a2302c19c658cf74e5ee1427605234e8c91787cfba0015f2ace145b/rignore-0.7.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:602ef33f3e1b04c1e9a10a3c03f8bc3cef2d2383dcc250d309be42b49923cabc", size = 1127702, upload-time = "2025-11-05T21:41:10.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d3/18210222b37e87e36357f7b300b7d98c6dd62b133771e71ae27acba83a4f/rignore-0.7.6-cp314-cp314t-win32.whl", hash = "sha256:c1d8f117f7da0a4a96a8daef3da75bc090e3792d30b8b12cfadc240c631353f9", size = 647033, upload-time = "2025-11-05T21:42:00.095Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/87/033eebfbee3ec7d92b3bb1717d8f68c88e6fc7de54537040f3b3a405726f/rignore-0.7.6-cp314-cp314t-win_amd64.whl", hash = "sha256:ca36e59408bec81de75d307c568c2d0d410fb880b1769be43611472c61e85c96", size = 725647, upload-time = "2025-11-05T21:41:44.449Z" },
+    { url = "https://files.pythonhosted.org/packages/79/62/b88e5879512c55b8ee979c666ee6902adc4ed05007226de266410ae27965/rignore-0.7.6-cp314-cp314t-win_arm64.whl", hash = "sha256:b83adabeb3e8cf662cabe1931b83e165b88c526fa6af6b3aa90429686e474896", size = 656035, upload-time = "2025-11-05T21:41:31.13Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/b3/fb8291170d0e844173164709fc0fa0c221ed75a5da740c8746f2a83b4eb1/sentry_sdk-2.58.0.tar.gz", hash = "sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f", size = 438764, upload-time = "2026-04-13T17:23:26.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/eb/d875669993b762556ae8b2efd86219943b4c0864d22204d622a9aee3052b/sentry_sdk-2.58.0-py2.py3-none-any.whl", hash = "sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e", size = 460919, upload-time = "2026-04-13T17:23:24.675Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "0.50.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150, upload-time = "2026-04-26T08:46:14.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993, upload-time = "2026-04-26T08:46:15.889Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.34.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ad/713be230bcda622eaa35c28f0d328c3675c371238470abdea52417f17a8e/uvicorn-0.34.3.tar.gz", hash = "sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a", size = 76631, upload-time = "2025-06-01T07:48:17.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/0d/8adfeaa62945f90d19ddc461c55f4a50c258af7662d34b6a3d5d1f8646f6/uvicorn-0.34.3-py3-none-any.whl", hash = "sha256:16246631db62bdfbf069b0645177d6e8a77ba950cfedbfd093acef9444e4d885", size = 62431, upload-time = "2025-06-01T07:48:15.664Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wheel"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/62/75f18a0f03b4219c456652c7780e4d749b929eb605c098ce3a5b6b6bc081/wheel-0.47.0.tar.gz", hash = "sha256:cc72bd1009ba0cf63922e28f94d9d83b920aa2bb28f798a31d0691b02fa3c9b3", size = 63854, upload-time = "2026-04-22T15:51:27.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/1b/9e33c09813d65e248f7f773119148a612516a4bea93e9c6f545f78455b7c/wheel-0.47.0-py3-none-any.whl", hash = "sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced", size = 32218, upload-time = "2026-04-22T15:51:26.296Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
+]

--- a/uv.lock
+++ b/uv.lock
@@ -509,7 +509,7 @@ wheels = [
 [[package]]
 name = "metranova-core"
 version = "0.1.0"
-source = { git = "https://github.com/MetrANOVA/api.git?subdirectory=packages%2Fmetranova&branch=main#453435a6ccab7a54d070d8026bdb57d97558a9bb" }
+source = { git = "https://github.com/MetrANOVA/api.git?subdirectory=packages%2Fmetranova&branch=js-transformers#5ab1b9ead8b1e685094e039747049a1311b24c8a" }
 dependencies = [
     { name = "clickhouse-connect" },
     { name = "fastapi", extra = ["standard"] },
@@ -568,7 +568,7 @@ requires-dist = [
     { name = "cachetools", specifier = "==6.2.1" },
     { name = "clickhouse-connect", specifier = "==0.15.0" },
     { name = "confluent-kafka", specifier = "==2.14.0" },
-    { name = "metranova-core", git = "https://github.com/MetrANOVA/api.git?subdirectory=packages%2Fmetranova&branch=main" },
+    { name = "metranova-core", git = "https://github.com/MetrANOVA/api.git?subdirectory=packages%2Fmetranova&branch=js-transformers" },
     { name = "orjson", specifier = "==3.11.3" },
     { name = "pycountry", specifier = "==24.6.1" },
     { name = "pycountry-convert", specifier = "==0.7.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -507,9 +507,9 @@ wheels = [
 ]
 
 [[package]]
-name = "metranova"
+name = "metranova-core"
 version = "0.1.0"
-source = { git = "https://github.com/MetrANOVA/api.git?subdirectory=packages%2Fmetranova&branch=main#e7e530b0435b3a054d9c0fe72f9ad14d51c712de" }
+source = { git = "https://github.com/MetrANOVA/api.git?subdirectory=packages%2Fmetranova&branch=main#453435a6ccab7a54d070d8026bdb57d97558a9bb" }
 dependencies = [
     { name = "clickhouse-connect" },
     { name = "fastapi", extra = ["standard"] },
@@ -547,13 +547,13 @@ wheels = [
 
 [[package]]
 name = "pipeline"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
     { name = "clickhouse-connect" },
     { name = "confluent-kafka" },
-    { name = "metranova" },
+    { name = "metranova-core" },
     { name = "orjson" },
     { name = "pycountry" },
     { name = "pycountry-convert" },
@@ -568,7 +568,7 @@ requires-dist = [
     { name = "cachetools", specifier = "==6.2.1" },
     { name = "clickhouse-connect", specifier = "==0.15.0" },
     { name = "confluent-kafka", specifier = "==2.14.0" },
-    { name = "metranova", git = "https://github.com/MetrANOVA/api.git?subdirectory=packages%2Fmetranova&branch=main" },
+    { name = "metranova-core", git = "https://github.com/MetrANOVA/api.git?subdirectory=packages%2Fmetranova&branch=main" },
     { name = "orjson", specifier = "==3.11.3" },
     { name = "pycountry", specifier = "==24.6.1" },
     { name = "pycountry-convert", specifier = "==0.7.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -509,7 +509,7 @@ wheels = [
 [[package]]
 name = "metranova-core"
 version = "0.1.0"
-source = { git = "https://github.com/MetrANOVA/api.git?subdirectory=packages%2Fmetranova&branch=js-transformers#5ab1b9ead8b1e685094e039747049a1311b24c8a" }
+source = { git = "https://github.com/MetrANOVA/api.git?subdirectory=packages%2Fmetranova&branch=main#c7d79f7b02baf138c795cfc7e7d01404cb64b35b" }
 dependencies = [
     { name = "clickhouse-connect" },
     { name = "fastapi", extra = ["standard"] },
@@ -568,7 +568,7 @@ requires-dist = [
     { name = "cachetools", specifier = "==6.2.1" },
     { name = "clickhouse-connect", specifier = "==0.15.0" },
     { name = "confluent-kafka", specifier = "==2.14.0" },
-    { name = "metranova-core", git = "https://github.com/MetrANOVA/api.git?subdirectory=packages%2Fmetranova&branch=js-transformers" },
+    { name = "metranova-core", git = "https://github.com/MetrANOVA/api.git?subdirectory=packages%2Fmetranova&branch=main" },
     { name = "orjson", specifier = "==3.11.3" },
     { name = "pycountry", specifier = "==24.6.1" },
     { name = "pycountry-convert", specifier = "==0.7.2" },


### PR DESCRIPTION
- Added metranova-core as a dependency. This is a shared lib between pipeline and api hosted under the api project. Can be broken out later on if needed. Required removal of `metranova/__init__.py` to make module namespaces work correctly.
- Updated `column_names` to take an optional param `table_name`. This is used by the DynamicProcessor to return the correct set of columns to save
- Add DynamicPipeline for use with ClickHouse
- Accidentally ran Black on a few things I shouldn't have. I'm sorry about that.