### PR TITLE
feat: clickhouse cluster distributed tables

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -72,6 +72,22 @@ This document describes all environment variables used by the MetrANOVA Pipeline
 | `CLICKHOUSE_REPLICA_PATH` | `/clickhouse/tables/{shard}/{database}/{table}` | ZooKeeper path for replicated tables |
 | `CLICKHOUSE_REPLICA_NAME` | `{replica}` | Replica name identifier |
 
+### Distributed Table Settings
+
+Distributed tables are query routers (ClickHouse `Distributed` engine) that fan out reads to the local tables on every shard/replica in the cluster. They let tools like Grafana query a single table (e.g. `data_flow_distributed`) instead of wrapping reads in `clusterAllReplicas()`/`remote()`. Data is still inserted into the local tables; the Distributed companion is read-only. These are only created when `CLICKHOUSE_CLUSTER_NAME` is set **and** the relevant distributed flag is enabled.
+
+`CLICKHOUSE_DISTRIBUTED` is the global default. When it is enabled (and a cluster is configured), Distributed companions are created for the **flow table** and its **materialized view** tables. Each has a per-table flag that overrides the global default (and a `*_DISTRIBUTED_TABLE` to override the generated name); MV flags follow the per-window pattern documented under [Per-Window Materialized View Settings](#per-window-materialized-view-settings).
+
+Metadata tables are intentionally **not** distributed. They are reference tables that exist in full on every shard (so dictionary/JOIN enrichment resolves locally), and a `Distributed` union over them would return one copy of each row per shard. Query the local `meta_*` table directly - it is identical on every node. Other data tables (interface traffic, raw kafka, generic metrics) are likewise not distributed.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLICKHOUSE_DISTRIBUTED` | `false` | Global default: create Distributed companion tables for the flow and MV tables (cluster only) |
+| `CLICKHOUSE_DISTRIBUTED_SUFFIX` | `_distributed` | Suffix appended to a local table name to form the Distributed table name |
+| `CLICKHOUSE_DISTRIBUTED_SHARDING_KEY` | `rand()` | Sharding key expression used in the `Distributed` engine definition |
+| `CLICKHOUSE_FLOW_DISTRIBUTED` | (global default) | Create a Distributed companion for the flow table |
+| `CLICKHOUSE_FLOW_DISTRIBUTED_TABLE` | `data_flow_distributed` | Override the flow Distributed table name |
+
 ### Table TTL Settings
 
 | Variable | Default | Description |
@@ -124,6 +140,8 @@ For each materialized view type and aggregation window (replace `{MV_TYPE}` with
 | `CLICKHOUSE_FLOW_MV_BY_{MV_TYPE}_{WINDOW}_POLICY_LEVEL` | `tlp:green` | Policy level override for aggregated data |
 | `CLICKHOUSE_FLOW_MV_BY_{MV_TYPE}_{WINDOW}_POLICY_SCOPE` | `comm:re` | Policy scope override (comma-separated list) |
 | `CLICKHOUSE_FLOW_MV_BY_{MV_TYPE}_{WINDOW}_POLICY_OVERRIDE` | `true` | Enable policy override for this materialized view |
+| `CLICKHOUSE_FLOW_MV_BY_{MV_TYPE}_{WINDOW}_DISTRIBUTED` | (global default) | Create a Distributed companion for this materialized view table (cluster only) |
+| `CLICKHOUSE_FLOW_MV_BY_{MV_TYPE}_{WINDOW}_DISTRIBUTED_TABLE` | `data_flow_by_{type}_{window}_distributed` | Custom name for the Distributed companion table |
 
 **Example:**
 ```

--- a/metranova/processors/clickhouse/base.py
+++ b/metranova/processors/clickhouse/base.py
@@ -16,10 +16,31 @@ class BaseClickHouseTableMixin:
         self.logger = logger
 
         # ClickHouse configuration from environment
+        self.database = os.getenv('CLICKHOUSE_DATABASE', 'default')
         self.cluster_name = os.getenv('CLICKHOUSE_CLUSTER_NAME', None)
         self.replication = os.getenv('CLICKHOUSE_REPLICATION', 'false').lower() in ['1', 'true', 'yes']
         self.replica_path = os.getenv('CLICKHOUSE_REPLICA_PATH', '/clickhouse/tables/{shard}/{database}/{table}')
         self.replica_name = os.getenv('CLICKHOUSE_REPLICA_NAME', '{replica}')
+
+        # Distributed table settings - only used when a cluster is configured.
+        # A Distributed table is a query router that fans out to the local tables on
+        # every shard/replica in the cluster. It lets tools like Grafana query a single
+        # table (e.g. data_flow_distributed) instead of wrapping reads in
+        # clusterAllReplicas()/remote(). Data is still inserted into the local table;
+        # the Distributed companion is read-only here.
+        # CLICKHOUSE_DISTRIBUTED is the global default. self.distributed is this table's
+        # resolved on/off state and defaults to off - a processor opts in by setting it.
+        # Flow and MV tables resolve a per-table flag that falls back to the global default
+        # via get_distributed_setting(). Metadata tables are intentionally NOT distributed:
+        # they are reference tables present on every shard (so dictionary/JOIN enrichment
+        # resolves locally), and a Distributed union over them would return one copy per
+        # shard - query the local meta_* table directly instead.
+        self.distributed_global = os.getenv('CLICKHOUSE_DISTRIBUTED', 'false').lower() in ['1', 'true', 'yes']
+        self.distributed = False
+        self.distributed_suffix = os.getenv('CLICKHOUSE_DISTRIBUTED_SUFFIX', '_distributed')
+        self.distributed_sharding_key = os.getenv('CLICKHOUSE_DISTRIBUTED_SHARDING_KEY', 'rand()')
+        # optional explicit distributed table name override (per-table); defaults to <table><suffix>
+        self.distributed_table = ""
         self.table_engine = "MergeTree"
         self.table_engine_opts = ""
         self.table_granularity = 8192  # default ClickHouse index granularity
@@ -125,6 +146,41 @@ class BaseClickHouseTableMixin:
             table_settings["ttl_only_drop_parts"] = "1"
         create_table_cmd += "SETTINGS {} \n".format(",".join(["{} = {}".format(k, v) for k, v in sorted(table_settings.items())]))
         return create_table_cmd
+
+    def distributed_enabled(self) -> bool:
+        """Distributed tables only make sense on a cluster and when explicitly enabled."""
+        return bool(self.distributed and self.cluster_name)
+
+    def get_distributed_setting(self, env_var_name: str) -> bool:
+        """Resolve a per-table distributed flag, falling back to the global CLICKHOUSE_DISTRIBUTED default."""
+        val = os.getenv(env_var_name, None)
+        if val is None:
+            return self.distributed_global
+        return val.lower() in ['1', 'true', 'yes']
+
+    def create_distributed_table_command(self, table_name=None) -> str | None:
+        """Return a CREATE TABLE command for a Distributed companion of the given local table.
+
+        The Distributed table routes queries across all shards/replicas in the cluster so
+        that tools like Grafana can query a single table instead of using
+        clusterAllReplicas()/remote(). Data continues to be inserted into the local table;
+        the Distributed companion is read-only here. Returns None when no cluster is configured.
+        """
+        if not self.cluster_name:
+            return None
+        if not table_name:
+            table_name = self.table
+        if not table_name:
+            raise ValueError("Table name is not set")
+        distributed_table_name = self.distributed_table or f"{table_name}{self.distributed_suffix}"
+        # `AS <local_table>` copies the column structure; ENGINE = Distributed overrides the engine.
+        create_cmd = "CREATE TABLE IF NOT EXISTS {} ".format(distributed_table_name)
+        create_cmd += f"ON CLUSTER '{self.cluster_name}' "
+        create_cmd += "AS {} \n".format(table_name)
+        create_cmd += "ENGINE = Distributed('{}', '{}', '{}', {}) \n".format(
+            self.cluster_name, self.database, table_name, self.distributed_sharding_key
+        )
+        return create_cmd
 
     def get_extension_defs(self, env_var_name: str, extension_options: dict, json_column_name: str = "ext") -> list:
         """Get extension column definitions from environment variable and applies only those in extension_options which takes form {extension_name: [[col_name, col_definition], ...]}"""

--- a/metranova/processors/clickhouse/flow.py
+++ b/metranova/processors/clickhouse/flow.py
@@ -13,6 +13,9 @@ class BaseFlowProcessor(BaseDataProcessor):
         self.table_ttl_column = os.getenv('CLICKHOUSE_FLOW_TTL_COLUMN', 'start_time')
         self.flow_type = os.getenv('CLICKHOUSE_FLOW_TYPE', 'unknown')
         self.partition_by = os.getenv('CLICKHOUSE_FLOW_PARTITION_BY', "toYYYYMMDD(start_time)")
+        # Distributed companion table (cluster only). Per-table flag falls back to the global CLICKHOUSE_DISTRIBUTED.
+        self.distributed = self.get_distributed_setting('CLICKHOUSE_FLOW_DISTRIBUTED')
+        self.distributed_table = os.getenv('CLICKHOUSE_FLOW_DISTRIBUTED_TABLE', '')
         self.policy_auto_scopes = os.getenv('CLICKHOUSE_FLOW_POLICY_AUTO_SCOPES', 'true').lower() in ('true', '1', 'yes')
         #A comma separated list of key-value pairs in form key:value, mapping a community id (such as a l3vpn rd) to a scope string
         policy_community_scope_map_str = os.getenv('CLICKHOUSE_FLOW_POLICY_COMMUNITY_SCOPE_MAP', None)
@@ -147,6 +150,9 @@ class MaterializedViewByEdgeAS(BaseClickHouseMaterializedViewMixin):
         self.extension_defs['ext'] = self.get_extension_defs('CLICKHOUSE_FLOW_EXTENSIONS', extension_options)
         agg_window_upper = agg_window.upper()
         self.table = os.getenv(f'CLICKHOUSE_FLOW_MV_BY_EDGE_AS_{agg_window_upper}_TABLE', f'data_flow_by_edge_as_{agg_window}')
+        # Distributed companion table (cluster only). Per-table flag falls back to the global CLICKHOUSE_DISTRIBUTED.
+        self.distributed = self.get_distributed_setting(f'CLICKHOUSE_FLOW_MV_BY_EDGE_AS_{agg_window_upper}_DISTRIBUTED')
+        self.distributed_table = os.getenv(f'CLICKHOUSE_FLOW_MV_BY_EDGE_AS_{agg_window_upper}_DISTRIBUTED_TABLE', '')
         self.table_ttl = os.getenv(f'CLICKHOUSE_FLOW_MV_BY_EDGE_AS_{agg_window_upper}_TTL', '5 YEAR')
         self.table_ttl_column = os.getenv(f'CLICKHOUSE_FLOW_MV_BY_EDGE_AS_{agg_window_upper}_TTL_COLUMN', 'start_time')
         self.partition_by = os.getenv(f'CLICKHOUSE_FLOW_MV_BY_EDGE_AS_{agg_window_upper}_PARTITION_BY', "toYYYYMMDD(start_time)")
@@ -260,6 +266,9 @@ class MaterializedViewByInterface(BaseClickHouseMaterializedViewMixin):
         ]
         agg_window_upper = agg_window.upper()
         self.table = os.getenv(f'CLICKHOUSE_FLOW_MV_BY_INTERFACE_{agg_window_upper}_TABLE', f'data_flow_by_interface_{agg_window}')
+        # Distributed companion table (cluster only). Per-table flag falls back to the global CLICKHOUSE_DISTRIBUTED.
+        self.distributed = self.get_distributed_setting(f'CLICKHOUSE_FLOW_MV_BY_INTERFACE_{agg_window_upper}_DISTRIBUTED')
+        self.distributed_table = os.getenv(f'CLICKHOUSE_FLOW_MV_BY_INTERFACE_{agg_window_upper}_DISTRIBUTED_TABLE', '')
         self.table_ttl = os.getenv(f'CLICKHOUSE_FLOW_MV_BY_INTERFACE_{agg_window_upper}_TTL', '5 YEAR')
         self.table_ttl_column = os.getenv(f'CLICKHOUSE_FLOW_MV_BY_INTERFACE_{agg_window_upper}_TTL_COLUMN', 'start_time')
         self.partition_by = os.getenv(f'CLICKHOUSE_FLOW_MV_BY_INTERFACE_{agg_window_upper}_PARTITION_BY', "toYYYYMMDD(start_time)")
@@ -336,6 +345,9 @@ class MaterializedViewByIPVersion(BaseClickHouseMaterializedViewMixin):
         ]
         agg_window_upper = agg_window.upper()
         self.table = os.getenv(f'CLICKHOUSE_FLOW_MV_BY_IP_VERSION_{agg_window_upper}_TABLE', f'data_flow_by_ip_version_{agg_window}')
+        # Distributed companion table (cluster only). Per-table flag falls back to the global CLICKHOUSE_DISTRIBUTED.
+        self.distributed = self.get_distributed_setting(f'CLICKHOUSE_FLOW_MV_BY_IP_VERSION_{agg_window_upper}_DISTRIBUTED')
+        self.distributed_table = os.getenv(f'CLICKHOUSE_FLOW_MV_BY_IP_VERSION_{agg_window_upper}_DISTRIBUTED_TABLE', '')
         self.table_ttl = os.getenv(f'CLICKHOUSE_FLOW_MV_BY_IP_VERSION_{agg_window_upper}_TTL', '5 YEAR')
         self.table_ttl_column = os.getenv(f'CLICKHOUSE_FLOW_MV_BY_IP_VERSION_{agg_window_upper}_TTL_COLUMN', 'start_time')
         self.partition_by = os.getenv(f'CLICKHOUSE_FLOW_MV_BY_IP_VERSION_{agg_window_upper}_PARTITION_BY', "toYYYYMMDD(start_time)")

--- a/metranova/writers/clickhouse.py
+++ b/metranova/writers/clickhouse.py
@@ -97,6 +97,27 @@ class ClickHouseBatcher:
         except Exception as e:
             logger.error(f"Failed to create table {table_name}: {e}")
             raise
+        # Create a Distributed companion table if enabled (cluster only)
+        self.create_distributed_table(self.processor, table_name)
+
+    def create_distributed_table(self, table_obj, table_name):
+        """Create a Distributed companion table for table_name if enabled and a cluster is configured.
+
+        table_obj is the processor or materialized view that owns the local table - it provides
+        the distributed_enabled() check and create_distributed_table_command() builder.
+        """
+        if not getattr(table_obj, "distributed_enabled", None) or not table_obj.distributed_enabled():
+            return
+        create_dist_cmd = table_obj.create_distributed_table_command(table_name=table_name)
+        if create_dist_cmd is None:
+            return
+        try:
+            self.logger.debug(f"Creating distributed table with command: {create_dist_cmd}")
+            self.client.command(create_dist_cmd)
+            logger.info(f"Distributed table for {table_name} is ready")
+        except Exception as e:
+            logger.error(f"Failed to create distributed table for {table_name}: {e}")
+            raise
 
     def create_dictionary(self, ch_dictionary):
         """Create the target dictionary if it doesn't exist"""
@@ -140,6 +161,8 @@ class ClickHouseBatcher:
                 f"Failed to create materialized view target table {materialized_view.table}: {e}"
             )
             raise
+        # Create a Distributed companion for the MV target table if enabled (cluster only)
+        self.create_distributed_table(materialized_view, materialized_view.table)
         # Create materialized view
         try:
             self.logger.debug(


### PR DESCRIPTION
This PR adds the ability to configure clickhouse distributed tables for the data_flow table, and all materialized views. There is a global environment variable `CLICKHOUSE_DISTRIBUTED` to turn on distributed tables for everything, or per-table settings under `CLICKHOUSE_FLOW_MV_BY_{MV_TYPE}_{WINDOW}_DISTRIBUTED`. 

This lets tools like Grafana query a single table instead of wrapping reads in `clusterAllReplicas()/remote()` when a sharded clickhouse cluster is being used. 