### PR TITLE
Issue 66 ip geo fix

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -96,6 +96,7 @@ This document describes all environment variables used by the MetrANOVA Pipeline
 | `CLICKHOUSE_FLOW_TYPE` | `unknown` | Flow data type identifier |
 | `CLICKHOUSE_FLOW_EXTENSIONS` | (none) | Comma-separated list of flow extensions to enable (e.g., `bgp,ipv4,ipv6,mpls`) |
 | `CLICKHOUSE_FLOW_IP_REF_EXTENSIONS` | (none) | Comma-separated list of IP reference extensions (e.g., `scireg`) |
+| `CLICKHOUSE_FLOW_IP_TO_AS_LOOKUP_ORDER` | `meta_ip` | Comma-separated preference order of IP metadata tables to use for AS lookups when AS is not provided in flow record (e.g., `meta_ip,meta_ip_scireg,meta_ip_cric`) |
 | `CLICKHOUSE_FLOW_POLICY_AUTO_SCOPES` | `true` | Automatically determine policy scopes from BGP communities |
 | `CLICKHOUSE_FLOW_POLICY_COMMUNITY_SCOPE_MAP` | (none) | Map BGP communities to policy scopes (format: `community:scope,community:scope`) |
 

--- a/metranova/consumers/metadata.py
+++ b/metranova/consumers/metadata.py
@@ -683,7 +683,7 @@ class IPGeolocationCSVConsumer(TimedIntervalConsumer):
         
         # Lookup ASN info in trie
         asn = ip_to_asn_trie.get(network, None)
-        if asn:
+        if asn is not None:
             ip_obj['as_id'] = asn
         
         # Lookup location info
@@ -705,8 +705,12 @@ class IPGeolocationCSVConsumer(TimedIntervalConsumer):
         return ip_obj, custom_ip_data
 
     def _process_ip_block_files(self, ip_to_asn_trie, location_code_map, custom_ip_data):
-        """Process IP block files and emit IP objects to pipeline"""
+        """Process IP block files and emit IP objects to pipeline.
+        Returns tuple of (custom_ip_data, processed_networks_set)
+        """
         # CSV Column names: network,geoname_id,registered_country_geoname_id,represented_country_geoname_id,is_anonymous_proxy,is_satellite_provider,postal_code,latitude,longitude,accuracy_radius,is_anycast
+        processed_networks = set()  # Track networks processed from City blocks
+        
         for ip_block_file in self.ip_block_files:
             try:
                 with open(ip_block_file, 'r') as f:
@@ -714,6 +718,7 @@ class IPGeolocationCSVConsumer(TimedIntervalConsumer):
                     for row in reader:
                         ip_obj, custom_ip_data = self._build_ip_object(row, ip_to_asn_trie, location_code_map, custom_ip_data)
                         if ip_obj:
+                            processed_networks.add(ip_obj['id'])  # Track this network
                             # Process the record - do this here to avoid memory issues with large files
                             # TODO: Possibly speed up imports by batching records instead of one at a time
                             self.pipeline.process_message({'table': self.table, 'data': [ip_obj]})
@@ -722,6 +727,55 @@ class IPGeolocationCSVConsumer(TimedIntervalConsumer):
             except Exception as e:
                 self.logger.error(f"Error processing IP Block file {ip_block_file}: {e}")
         
+        return custom_ip_data, processed_networks
+
+    def _process_remaining_asn_ranges(self, processed_networks, location_code_map, custom_ip_data):
+        """Process ASN ranges that don't have corresponding City blocks.
+        Only adds ASN ranges whose network ID is not already in processed_networks.
+        This ensures ASN-only ranges don't overwrite City blocks with better data.
+        """
+        asn_only_count = 0
+        
+        for asn_file in self.asn_files:
+            try:
+                with open(asn_file, 'r') as f:
+                    reader = csv.DictReader(f)
+                    for row in reader:
+                        network = row.get('network', None)
+                        asn = row.get('autonomous_system_number', None)
+                        
+                        if not network or asn is None:
+                            continue
+                        
+                        # Skip if this network was already processed from City blocks
+                        if network in processed_networks:
+                            continue
+                        
+                        # Build IP object with ASN data only
+                        ip_obj = {'id': network}
+                        ip_subnet_tuple = self.ip_subnet_to_tuple(network)
+                        ip_obj['ip_subnet'] = [ip_subnet_tuple]
+                        ip_obj['as_id'] = int(asn)
+                        
+                        # Try to lookup location data (most ASN-only ranges won't have this)
+                        # Note: ASN files don't have geoname_id, so this will typically be empty
+                        # but included for consistency with the data model
+                        
+                        # Merge with any custom data
+                        if custom_ip_data.get(network, None):
+                            ip_obj.update(custom_ip_data[network])
+                            del custom_ip_data[network]
+                        
+                        # Process the record
+                        self.pipeline.process_message({'table': self.table, 'data': [ip_obj]})
+                        asn_only_count += 1
+                        
+            except FileNotFoundError as e:
+                self.logger.error(f"ASN Block file not found: {asn_file}. Error: {e}")
+            except Exception as e:
+                self.logger.error(f"Error processing ASN Block file {asn_file}: {e}")
+        
+        self.logger.info(f"Added {asn_only_count} ASN-only IP ranges not present in City blocks")
         return custom_ip_data
 
     def consume_messages(self):
@@ -740,9 +794,14 @@ class IPGeolocationCSVConsumer(TimedIntervalConsumer):
         # Load custom IP data
         custom_ip_data = self._load_custom_ip_data()
         
-        # Process IP block files
-        remaining_custom_data = self._process_ip_block_files(ip_to_asn_trie, location_code_map, custom_ip_data)
+        # Process IP block files (City blocks with geo data, enriched with ASN)
+        remaining_custom_data, processed_networks = self._process_ip_block_files(ip_to_asn_trie, location_code_map, custom_ip_data)
         
-        # Process any remaining custom IP records that were not in the ip block files
+        # Process ASN ranges not covered by City blocks
+        # This adds ranges like 169.228.0.0/17 and AS 8517 IPv6 ranges that don't have geo data
+        # but don't overwrite or duplicate City block entries
+        remaining_custom_data = self._process_remaining_asn_ranges(processed_networks, location_code_map, remaining_custom_data)
+        
+        # Process any remaining custom IP records that were not in either file
         if remaining_custom_data:
             self.pipeline.process_message({'table': self.table, 'data': list(remaining_custom_data.values())})

--- a/metranova/processors/clickhouse/base.py
+++ b/metranova/processors/clickhouse/base.py
@@ -301,6 +301,14 @@ class BaseClickHouseProcessor(BaseProcessor, BaseClickHouseTableMixin):
         # List of materailized views to build (as BaseClickHouseMaterializedViewMixin objects)
         self.materialized_views = []
     
+    def set_clickhouse_client(self, client: HttpClient) -> None:
+        """Set the ClickHouse client for this processor.
+        
+        Most processors don't need direct client access, so this is a no-op by default.
+        Override in subclasses if direct client access is needed (e.g., for dynamic schema inspection).
+        """
+        return None
+    
     def get_ch_dictionaries(self) -> list:
         """Return list of ClickHouse dictionaries used by this processor. Override in child classes if multiple dictionaries are used."""
         return self.ch_dictionaries
@@ -641,18 +649,6 @@ class BaseDataProcessor(BaseClickHouseProcessor):
             ["policy_scope", "Array(LowCardinality(String))", True],
             ["ext", None, True]
         ]
-
-    def set_clickhouse_client(self, client: HttpClient) -> None:
-        """Set the ClickHouse client for this processor and any child classes that need it
-
-        The primary purpose of this method is to grant the processor direct access to the ClickHouse client.
-        While in most cases the processor will declare the database schema itself, the dynamic pipeline is
-        required to access the type definitions directly as they are declared via API.
-
-        NOTE: This method exists primarily to support the dynamic pipeline and may not be necessary for
-        other use cases.
-        """
-        return None
 
 
 class BaseDataGenericMetricProcessor(BaseDataProcessor):

--- a/metranova/processors/clickhouse/flow.py
+++ b/metranova/processors/clickhouse/flow.py
@@ -12,6 +12,7 @@ class BaseFlowProcessor(BaseDataProcessor):
         self.table_ttl = os.getenv('CLICKHOUSE_FLOW_TTL', '30 DAY')
         self.table_ttl_column = os.getenv('CLICKHOUSE_FLOW_TTL_COLUMN', 'start_time')
         self.flow_type = os.getenv('CLICKHOUSE_FLOW_TYPE', 'unknown')
+        self.ip_to_as_lookup_order = os.getenv('CLICKHOUSE_FLOW_IP_TO_AS_LOOKUP_ORDER', 'meta_ip').split(',')
         self.partition_by = os.getenv('CLICKHOUSE_FLOW_PARTITION_BY', "toYYYYMMDD(start_time)")
         self.policy_auto_scopes = os.getenv('CLICKHOUSE_FLOW_POLICY_AUTO_SCOPES', 'true').lower() in ('true', '1', 'yes')
         #A comma separated list of key-value pairs in form key:value, mapping a community id (such as a l3vpn rd) to a scope string

--- a/metranova/processors/clickhouse/pmacct.py
+++ b/metranova/processors/clickhouse/pmacct.py
@@ -136,18 +136,34 @@ class PMAcctFlowProcessor(BaseFlowProcessor):
             return
         as_id_field = f"{target_as_field}_id"
         formatted_record[as_id_field] = value.get(as_field, None)
+        
+        #Lookup ip ref, we'll lookup AS later
         ip_cache_result = self.pipeline.cacher("ip").lookup("meta_ip", formatted_record[target_ip_field])
         if ip_cache_result:
             formatted_record[f"{target_ip_field}_ref"] = ip_cache_result[0]
-            #if no AS provided in value (0 or None), see if we have one in the cached result
-            try:
-                if formatted_record[as_id_field] is None or int(formatted_record[as_id_field]) == 0:
-                    formatted_record[as_id_field] = ip_cache_result[1] if len(ip_cache_result) > 1 else None
-            except ValueError:
-                pass
         else:
             formatted_record[f"{target_ip_field}_ref"] = None
 
+        #lookup as_id if not provided, using ip preference order (may be different from cacher above which always uses meta_ip)
+        provided_as_id = formatted_record[as_id_field]
+        if provided_as_id is not None:
+            try:
+                provided_as_id = int(provided_as_id)
+            except ValueError:
+                provided_as_id = None
+            # give the formatted as_id
+            formatted_record[as_id_field] = provided_as_id
+        if provided_as_id is None or provided_as_id == 0:
+            for ip_to_as_table in self.ip_to_as_lookup_order:
+                as_cache_result = None
+                #optimize for the case where ip_to_as_table is meta_ip since we already did that lookup above
+                if ip_to_as_table == "meta_ip":
+                    as_cache_result = ip_cache_result
+                else:
+                    as_cache_result = self.pipeline.cacher("ip").lookup(ip_to_as_table, formatted_record[target_ip_field])
+                if as_cache_result and len(as_cache_result) > 1:
+                    formatted_record[as_id_field] = as_cache_result[1]
+                    break
         #set the as ref field
         formatted_record[f"{target_as_field}_ref"] = self.pipeline.cacher("clickhouse").lookup_dict_key("meta_as", formatted_record[as_id_field], "ref")
 

--- a/test/consumers/test_metadata.py
+++ b/test/consumers/test_metadata.py
@@ -1061,7 +1061,7 @@ class TestIPGeolocationCSVConsumer(unittest.TestCase):
         
         self.consumer.ip_block_files = ['/test/blocks1.csv']
         
-        remaining_custom = self.consumer._process_ip_block_files(
+        remaining_custom, processed_networks = self.consumer._process_ip_block_files(
             mock_trie, location_map, custom_data
         )
         
@@ -1070,6 +1070,10 @@ class TestIPGeolocationCSVConsumer(unittest.TestCase):
         
         # Verify custom data was updated (entry should be removed)
         self.assertNotIn('192.168.1.0/24', remaining_custom)
+        
+        # Verify networks were tracked
+        self.assertIn('192.168.1.0/24', processed_networks)
+        self.assertIn('10.0.0.0/8', processed_networks)
 
     @patch('builtins.open', new_callable=mock_open)
     def test_process_ip_block_files_file_error(self, mock_file):
@@ -1078,10 +1082,11 @@ class TestIPGeolocationCSVConsumer(unittest.TestCase):
         self.consumer.ip_block_files = ['/test/nonexistent.csv']
         
         with patch.object(self.consumer.logger, 'error') as mock_error:
-            remaining_custom = self.consumer._process_ip_block_files(Mock(), {}, {})
+            remaining_custom, processed_networks = self.consumer._process_ip_block_files(Mock(), {}, {})
         
         mock_error.assert_called_once()
         self.assertEqual(remaining_custom, {})
+        self.assertEqual(processed_networks, set())
 
     @patch('builtins.open', new_callable=mock_open)
     def test_process_ip_block_files_empty_network_skip(self, mock_file):
@@ -1093,17 +1098,19 @@ class TestIPGeolocationCSVConsumer(unittest.TestCase):
         mock_file.return_value = StringIO(ip_block_csv)
         self.consumer.ip_block_files = ['/test/blocks1.csv']
         
-        remaining_custom = self.consumer._process_ip_block_files(Mock(), {}, {})
+        remaining_custom, processed_networks = self.consumer._process_ip_block_files(Mock(), {}, {})
         
         # Should only process one message (the row with valid network)
         self.assertEqual(self.mock_pipeline.process_message.call_count, 1)
+        self.assertEqual(len(processed_networks), 1)
 
+    @patch.object(IPGeolocationCSVConsumer, '_process_remaining_asn_ranges')
     @patch.object(IPGeolocationCSVConsumer, '_process_ip_block_files')
     @patch.object(IPGeolocationCSVConsumer, '_load_custom_ip_data')
     @patch.object(IPGeolocationCSVConsumer, '_load_location_data')
     @patch.object(IPGeolocationCSVConsumer, '_load_asn_data')
     def test_consume_messages_method_integration(self, mock_load_asn, mock_load_location, 
-                                               mock_load_custom, mock_process_blocks):
+                                               mock_load_custom, mock_process_blocks, mock_process_asn):
         """Test consume_messages calls all helper methods in correct order."""
         # Mock return values
         mock_trie = Mock()
@@ -1116,7 +1123,10 @@ class TestIPGeolocationCSVConsumer(unittest.TestCase):
         mock_load_custom.return_value = custom_data
         
         remaining_custom = {'10.0.0.0/8': {'remaining': 'data'}}
-        mock_process_blocks.return_value = remaining_custom
+        processed_networks = {'192.168.1.0/24', '172.16.0.0/12'}
+        mock_process_blocks.return_value = (remaining_custom, processed_networks)
+        
+        mock_process_asn.return_value = remaining_custom
         
         self.consumer.consume_messages()
         
@@ -1125,6 +1135,7 @@ class TestIPGeolocationCSVConsumer(unittest.TestCase):
         mock_load_location.assert_called_once()
         mock_load_custom.assert_called_once()
         mock_process_blocks.assert_called_once_with(mock_trie, location_map, custom_data)
+        mock_process_asn.assert_called_once_with(processed_networks, location_map, remaining_custom)
         
         # Verify remaining custom data was processed
         self.mock_pipeline.process_message.assert_called_once_with({
@@ -1132,18 +1143,20 @@ class TestIPGeolocationCSVConsumer(unittest.TestCase):
             'data': [{'remaining': 'data'}]
         })
 
+    @patch.object(IPGeolocationCSVConsumer, '_process_remaining_asn_ranges')
     @patch.object(IPGeolocationCSVConsumer, '_process_ip_block_files')
     @patch.object(IPGeolocationCSVConsumer, '_load_custom_ip_data')
     @patch.object(IPGeolocationCSVConsumer, '_load_location_data')
     @patch.object(IPGeolocationCSVConsumer, '_load_asn_data')
     def test_consume_messages_no_remaining_custom_data(self, mock_load_asn, mock_load_location,
-                                                      mock_load_custom, mock_process_blocks):
+                                                      mock_load_custom, mock_process_blocks, mock_process_asn):
         """Test consume_messages when no custom data remains after processing."""
         # Mock return values with empty remaining custom data
         mock_load_asn.return_value = Mock()
         mock_load_location.return_value = {}
         mock_load_custom.return_value = {}
-        mock_process_blocks.return_value = {}  # No remaining custom data
+        mock_process_blocks.return_value = ({}, set())  # No remaining custom data
+        mock_process_asn.return_value = {}
         
         self.consumer.consume_messages()
         
@@ -1649,19 +1662,21 @@ class TestIPGeolocationCSVConsumerMaxMindDownload(unittest.TestCase):
             self.assertTrue(result)
             mock_asn.assert_not_called()
 
+    @patch.object(IPGeolocationCSVConsumer, '_process_remaining_asn_ranges')
     @patch.object(IPGeolocationCSVConsumer, '_ensure_maxmind_data')
     @patch.object(IPGeolocationCSVConsumer, '_load_asn_data')
     @patch.object(IPGeolocationCSVConsumer, '_load_location_data')
     @patch.object(IPGeolocationCSVConsumer, '_load_custom_ip_data')
     @patch.object(IPGeolocationCSVConsumer, '_process_ip_block_files')
     def test_consume_messages_calls_ensure_maxmind_data(self, mock_process, mock_custom, 
-                                                         mock_location, mock_asn, mock_ensure):
+                                                         mock_location, mock_asn, mock_ensure, mock_process_asn):
         """Test consume_messages calls _ensure_maxmind_data."""
         mock_ensure.return_value = True
         mock_asn.return_value = {}
         mock_location.return_value = {}
         mock_custom.return_value = {}
-        mock_process.return_value = {}
+        mock_process.return_value = ({}, set())
+        mock_process_asn.return_value = {}
         
         self.consumer.consume_messages()
         


### PR DESCRIPTION
This pull request introduces improvements to the handling and processing of IP geolocation and ASN (Autonomous System Number) data in the MetrANOVA Pipeline, with a focus on more robust merging of city and ASN block data, enhanced configurability for IP-to-AS lookups, and expanded test coverage. The changes help ensure that ASN-only ranges are incorporated without overwriting more detailed city block data, and allow for configurable lookup order of IP metadata sources.

**Enhancements to IP/ASN data processing:**

* The `_process_ip_block_files` method in `metadata.py` now returns both remaining custom IP data and a set of processed network IDs, enabling tracking of which networks have already been handled. This prevents ASN-only records from overwriting city block data and improves data accuracy. (`metranova/consumers/metadata.py`) [[1]](diffhunk://#diff-ea6973592cc73d8442ae7255c6ef7b647d0c91a5b1b5fda08259b0771ba995d8L708-R721) [[2]](diffhunk://#diff-ea6973592cc73d8442ae7255c6ef7b647d0c91a5b1b5fda08259b0771ba995d8R730-R778) [[3]](diffhunk://#diff-ea6973592cc73d8442ae7255c6ef7b647d0c91a5b1b5fda08259b0771ba995d8L743-R805)
* A new method `_process_remaining_asn_ranges` is added, which processes ASN block files and only inserts ASN-only ranges that have not already been covered by city blocks. This ensures that more complete city block data is preserved. (`metranova/consumers/metadata.py`) [[1]](diffhunk://#diff-ea6973592cc73d8442ae7255c6ef7b647d0c91a5b1b5fda08259b0771ba995d8R730-R778) [[2]](diffhunk://#diff-ea6973592cc73d8442ae7255c6ef7b647d0c91a5b1b5fda08259b0771ba995d8L743-R805)

**Configurability and lookup improvements:**

* The environment variable `CLICKHOUSE_FLOW_IP_TO_AS_LOOKUP_ORDER` is now documented and used to control the preference order of IP metadata tables for AS lookups, allowing deployments to prioritize different data sources. (`docs/env_vars.md`, `metranova/processors/clickhouse/flow.py`) [[1]](diffhunk://#diff-d2ee9105e8b962cfeebd3b65929eab8c2b398e2bd6f55fe19bfef40223e6befeR99) [[2]](diffhunk://#diff-dc08462dea3a28fd465d6bc9b2a3ac02f652f5a097d2d6b1a5fa7a92a02ef2e0R15)
* The AS lookup logic in `pmacct.py` is updated to use the configured lookup order, falling back across multiple metadata sources if an AS is not found in the primary table. (`metranova/processors/clickhouse/pmacct.py`)

**Testing and code maintenance:**

* Unit tests for the consumer have been updated to reflect the new return values and logic, including checks for tracking processed networks and the integration of ASN-only range processing. (`test/consumers/test_metadata.py`) [[1]](diffhunk://#diff-c9dfd7c2faee6b0986e5dd9f325675b55da592614bc4d04507d3b36153579df1L1064-R1064) [[2]](diffhunk://#diff-c9dfd7c2faee6b0986e5dd9f325675b55da592614bc4d04507d3b36153579df1R1074-R1089) [[3]](diffhunk://#diff-c9dfd7c2faee6b0986e5dd9f325675b55da592614bc4d04507d3b36153579df1L1096-R1113) [[4]](diffhunk://#diff-c9dfd7c2faee6b0986e5dd9f325675b55da592614bc4d04507d3b36153579df1L1119-R1129) [[5]](diffhunk://#diff-c9dfd7c2faee6b0986e5dd9f325675b55da592614bc4d04507d3b36153579df1R1138-R1159) [[6]](diffhunk://#diff-c9dfd7c2faee6b0986e5dd9f325675b55da592614bc4d04507d3b36153579df1R1665-R1679)
* Redundant or relocated methods, such as `set_clickhouse_client`, have been cleaned up in the base processor classes to avoid duplication. (`metranova/processors/clickhouse/base.py`) [[1]](diffhunk://#diff-fd1d56896fa514a8d516384bbca8cdbd6c5c4148599baba0c8856022414b1bfaR304-R311) [[2]](diffhunk://#diff-fd1d56896fa514a8d516384bbca8cdbd6c5c4148599baba0c8856022414b1bfaL645-L656)

These updates together ensure more accurate and configurable IP-to-ASN mapping and improve the maintainability and testability of the data ingestion pipeline.